### PR TITLE
Pin Xray-core to v26.7.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ env:
   NDK_VERSION: r29
   LIBXRAY_REF: main
   XRAY_CORE_REPOSITORY: XTLS/Xray-core
-  XRAY_CORE_REF: main
+  XRAY_CORE_REF: v26.7.11
   BUILD_NUMBER: ${{ github.run_number }}
 
 jobs:


### PR DESCRIPTION
## Summary

- Pin the App build workflow to `XTLS/Xray-core@v26.7.11`.
- Ensure every platform build uses the same Xray-core release tag.

## Validation

- Workflow YAML parsed successfully.
- `git diff --check`