### PR TITLE
Refine navigation and Raw JSON handling

### DIFF
--- a/lib/pages/core/xray/raw/controller.dart
+++ b/lib/pages/core/xray/raw/controller.dart
@@ -155,13 +155,13 @@ class XrayRawController extends PageCubit<XrayRawPageState> {
   Future<void> realPing(BuildContext context) async {
     final rawText = controller.text.trim();
     final check = await XrayRawValidator.validate(rawText);
-    if (check.item1) {
+    if (check.isValid) {
       final eventBus = AppEventBus.instance;
       eventBus.updatePinging(true);
       final pingState = PingState();
       await pingState.readFromPreferences();
       final res = await XrayRawPing.ping(
-        rawText,
+        check.normalizedText!,
         pingState,
         fallbackDelay: PingDelayConstants.error,
       );
@@ -171,7 +171,7 @@ class XrayRawController extends PageCubit<XrayRawPageState> {
       }
     } else {
       if (context.mounted) {
-        ContextAlert.showToast(context, check.item2);
+        ContextAlert.showToast(context, check.error);
       }
     }
   }
@@ -179,14 +179,14 @@ class XrayRawController extends PageCubit<XrayRawPageState> {
   Future<void> save(BuildContext context) async {
     final rawText = controller.text.trim();
     final check = await XrayRawValidator.validate(rawText);
-    if (check.item1) {
-      await _updateDb(rawText);
+    if (check.isValid) {
+      await _updateDb(check.normalizedText!);
       if (context.mounted) {
         context.pop();
       }
     } else {
       if (context.mounted) {
-        ContextAlert.showToast(context, check.item2);
+        ContextAlert.showToast(context, check.error);
       }
     }
   }

--- a/lib/pages/theme/theme.dart
+++ b/lib/pages/theme/theme.dart
@@ -148,7 +148,6 @@ abstract final class AppTheme {
         centerTitle: false,
         elevation: 0,
         scrolledUnderElevation: 0,
-        toolbarHeight: 66,
         titleSpacing: 20,
         actionsPadding: const EdgeInsetsDirectional.only(end: 12),
         titleTextStyle: AppTypography.pageTitle.copyWith(

--- a/lib/service/xray/raw/fix.dart
+++ b/lib/service/xray/raw/fix.dart
@@ -135,20 +135,30 @@ class XrayRawFix {
     }
   }
 
-  static void fixInboundsTun(Map<String, dynamic> jsonMap) {
-    XrayRuntimeInbounds.removeManagedRawInbounds(jsonMap);
+  static void keepOnlyPingInbound(
+    Map<String, dynamic> jsonMap, {
+    XrayPorts? ports,
+  }) {
+    jsonMap["inbounds"] = [_pingInbound(ports).toJson()];
+    _fixPingRoutingRule(jsonMap);
   }
 
   static void fixInboundsPort(Map<String, dynamic> jsonMap, XrayPorts ports) {
     final inbounds = _ensureList(jsonMap, "inbounds");
     inbounds.removeWhere(_isPingInbound);
 
-    final pingInbound = InboundPingState()
-      ..port = ports.pingPort
-      ..auth = ports.pingAuth;
-    inbounds.add(pingInbound.xrayJson.toJson());
+    inbounds.add(_pingInbound(ports).toJson());
 
     _fixPingRoutingRule(jsonMap);
+  }
+
+  static XrayInbound _pingInbound(XrayPorts? ports) {
+    final pingInbound = InboundPingState();
+    if (ports != null) {
+      pingInbound.port = ports.pingPort;
+      pingInbound.auth = ports.pingAuth;
+    }
+    return pingInbound.xrayJson;
   }
 
   static bool _isPingInbound(dynamic inbound) {

--- a/lib/service/xray/raw/ping.dart
+++ b/lib/service/xray/raw/ping.dart
@@ -19,11 +19,9 @@ class XrayRawPing {
       return fallbackDelay;
     }
     final jsonMap = JsonTool.decoder.convert(rawText);
-    //remove metrics
     XrayRawFix.fixMetrics(jsonMap);
-    XrayRawFix.fixInboundsTun(jsonMap);
     XrayRawFix.fixEnv(jsonMap);
-    XrayRawFix.fixInboundsPort(jsonMap, ports);
+    XrayRawFix.keepOnlyPingInbound(jsonMap, ports: ports);
     XrayRawFix.fixLog(jsonMap);
     final text = JsonTool.encoder.convert(jsonMap);
 

--- a/lib/service/xray/raw/validator.dart
+++ b/lib/service/xray/raw/validator.dart
@@ -7,42 +7,68 @@ import 'package:onexray/service/localizations/service.dart';
 import 'package:onexray/core/pigeon/constants.dart';
 import 'package:onexray/service/xray/raw/fix.dart';
 import 'package:onexray/service/xray/raw/writer.dart';
-import 'package:tuple/tuple.dart';
+
+class XrayRawValidationResult {
+  final bool isValid;
+  final String error;
+  final String? normalizedText;
+
+  const XrayRawValidationResult._(
+    this.isValid,
+    this.error,
+    this.normalizedText,
+  );
+
+  const XrayRawValidationResult.valid(String normalizedText)
+    : this._(true, "", normalizedText);
+
+  const XrayRawValidationResult.invalid(String error)
+    : this._(false, error, null);
+}
 
 class XrayRawValidator {
-  static Future<Tuple2<bool, String>> validate(String rawText) async {
-    Map<String, dynamic> jsonMap = {};
+  static Future<XrayRawValidationResult> validate(String rawText) async {
+    late final Map<String, dynamic> jsonMap;
+    late final XrayJson xrayJson;
     try {
-      jsonMap = JsonTool.decoder.convert(rawText);
+      final decoded = JsonTool.decoder.convert(rawText);
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException("Xray config root must be an object");
+      }
+      jsonMap = decoded;
+      xrayJson = XrayJson.fromJson(jsonMap);
     } catch (_) {
-      return Tuple2(false, appLocalizationsNoContext().validationJsonInvalid);
+      return XrayRawValidationResult.invalid(
+        appLocalizationsNoContext().validationJsonInvalid,
+      );
     }
-    final xrayJson = XrayJson.fromJson(jsonMap);
     if (!EmptyTool.checkString(xrayJson.name)) {
-      return Tuple2(false, appLocalizationsNoContext().validationNameRequired);
+      return XrayRawValidationResult.invalid(
+        appLocalizationsNoContext().validationNameRequired,
+      );
     }
 
+    XrayRawFix.keepOnlyPingInbound(jsonMap);
+    final normalizedText = JsonTool.encoder.convert(jsonMap);
     final res = await _test(jsonMap);
     if (res.isNotEmpty) {
-      return Tuple2(false, res);
+      return XrayRawValidationResult.invalid(res);
     }
 
-    return Tuple2(true, "");
+    return XrayRawValidationResult.valid(normalizedText);
   }
 
   static Future<String> _test(Map<String, dynamic> jsonMap) async {
-    // remove app-managed runtime inbounds
-    XrayRawFix.fixInboundsTun(jsonMap);
     XrayRawFix.fixEnv(jsonMap);
-    // remove metrics
     XrayRawFix.fixMetrics(jsonMap);
 
     final rawText = JsonTool.encoder.convert(jsonMap);
     final configPath = await XrayRawWriter.writeConfig(rawText);
-    await FileTool.checkDir(VpnConstants.runDir);
-    final res = await AppHostApi().testXray(configPath);
-    await FileTool.deleteFileIfExists(configPath);
-
-    return res;
+    try {
+      await FileTool.checkDir(VpnConstants.runDir);
+      return await AppHostApi().testXray(configPath);
+    } finally {
+      await FileTool.deleteFileIfExists(configPath);
+    }
   }
 }

--- a/lib/service/xray/runtime_inbounds.dart
+++ b/lib/service/xray/runtime_inbounds.dart
@@ -25,11 +25,6 @@ abstract final class XrayRuntimeInbounds {
     _fixRawRoutingInboundTags(jsonMap, mode);
   }
 
-  static void removeManagedRawInbounds(Map<String, dynamic> jsonMap) {
-    jsonMap.remove("inbounds");
-    _removeManagedRawRoutingRules(jsonMap);
-  }
-
   static void _fixXrayRoutingInboundTags(XrayJson xrayJson, CoreRunMode mode) {
     final rules = xrayJson.routing?.rules;
     if (rules == null) {
@@ -102,36 +97,5 @@ abstract final class XrayRuntimeInbounds {
         }
         return [tag];
     }
-  }
-
-  static void _removeManagedRawRoutingRules(Map<String, dynamic> jsonMap) {
-    final routing = jsonMap["routing"];
-    if (routing is! Map) {
-      return;
-    }
-    final rules = routing["rules"];
-    if (rules is! List) {
-      return;
-    }
-    rules.removeWhere((rule) {
-      if (rule is! Map) {
-        return false;
-      }
-      final inboundTag = rule["inboundTag"];
-      return _containsManagedInboundTag(inboundTag);
-    });
-  }
-
-  static bool _containsManagedInboundTag(dynamic inboundTag) {
-    final managed = {
-      RoutingInboundTag.tunIn.name,
-      RoutingInboundTag.socksIn.name,
-      RoutingInboundTag.httpIn.name,
-      RoutingInboundTag.pingIn.name,
-    };
-    if (inboundTag is List) {
-      return inboundTag.any(managed.contains);
-    }
-    return managed.contains(inboundTag);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -102,7 +102,7 @@ msix_config:
   publisher_display_name: Yuan Dev LLC
   identity_name: YuanDevLLC.OneXray
   publisher: CN=3666BCB5-5482-46DD-9C19-D8A7290A39FD
-  logo_path: assets/app_icon/blue.png
+  logo_path: assets/logo.png
   capabilities: allowElevation
   languages: en-us, zh-cn, zh-tw, ru-ru, fa-ir
   os_min_version: 10.0.17763.0

--- a/test/pages/theme/theme_test.dart
+++ b/test/pages/theme/theme_test.dart
@@ -21,7 +21,7 @@ void main() {
       expect(material.colorScheme.outline, palette.border);
       expect(material.appBarTheme.backgroundColor, palette.header);
       expect(material.appBarTheme.foregroundColor, palette.foreground);
-      expect(material.appBarTheme.toolbarHeight, 66);
+      expect(material.appBarTheme.toolbarHeight, isNull);
       expect(material.appBarTheme.titleSpacing, 20);
       expect(
         material.appBarTheme.actionsPadding,
@@ -38,6 +38,7 @@ void main() {
         Brightness.dark,
       );
       expect(material.navigationRailTheme.backgroundColor, palette.sidebar);
+      expect(material.navigationBarTheme.height, isNull);
 
       expect(shad.background, palette.background);
       expect(shad.foreground, palette.foreground);

--- a/test/service/xray/raw_fix_test.dart
+++ b/test/service/xray/raw_fix_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onexray/core/model/xray_json.dart';
+import 'package:onexray/service/xray/profile/inbounds_state.dart';
+import 'package:onexray/service/xray/raw/fix.dart';
+
+void main() {
+  test('Raw config keeps only the app-managed ping inbound', () {
+    final jsonMap = <String, dynamic>{
+      'inbounds': <dynamic>[
+        <String, dynamic>{'tag': 'tunIn', 'protocol': 'tun'},
+        <String, dynamic>{'tag': 'customIn', 'protocol': 'socks'},
+        <String, dynamic>{'tag': 'pingIn', 'protocol': 'http', 'port': '12345'},
+      ],
+      'outbounds': <dynamic>[
+        <String, dynamic>{'tag': 'proxy', 'protocol': 'freedom'},
+      ],
+      'routing': <String, dynamic>{
+        'rules': <dynamic>[
+          <String, dynamic>{
+            'inboundTag': <String>['tunIn'],
+            'outboundTag': 'proxy',
+            'ruleTag': 'userRule',
+          },
+          <String, dynamic>{
+            'inboundTag': <String>['pingIn'],
+            'outboundTag': 'direct',
+            'ruleTag': 'oldPingRule',
+          },
+        ],
+      },
+    };
+
+    XrayRawFix.keepOnlyPingInbound(jsonMap);
+
+    final inbounds = jsonMap['inbounds']! as List<dynamic>;
+    expect(inbounds, hasLength(1));
+    expect(inbounds.single, containsPair('tag', 'pingIn'));
+    expect(inbounds.single, containsPair('protocol', 'http'));
+    expect(inbounds.single, containsPair('port', '0'));
+
+    final routing = jsonMap['routing']! as Map<String, dynamic>;
+    final rules = routing['rules']! as List<dynamic>;
+    expect(rules, hasLength(2));
+    expect(rules.first, containsPair('ruleTag', 'ping'));
+    expect(rules.first, containsPair('outboundTag', 'proxy'));
+    expect(rules.last, containsPair('ruleTag', 'userRule'));
+  });
+
+  test('Raw ping config uses the allocated port and authentication', () {
+    final jsonMap = <String, dynamic>{
+      'outbounds': <dynamic>[
+        <String, dynamic>{'tag': 'direct', 'protocol': 'freedom'},
+      ],
+    };
+    final ports = XrayPorts(
+      '23456',
+      '23457',
+      XrayInboundAccount('ping-user', 'ping-pass'),
+    );
+
+    XrayRawFix.keepOnlyPingInbound(jsonMap, ports: ports);
+
+    final inbounds = jsonMap['inbounds']! as List<dynamic>;
+    final pingInbound = inbounds.single as Map<String, dynamic>;
+    expect(pingInbound['port'], '23456');
+    final settings = pingInbound['settings']! as Map<String, dynamic>;
+    final users = settings['users']! as List<dynamic>;
+    expect(users.single, <String, dynamic>{
+      'user': 'ping-user',
+      'pass': 'ping-pass',
+    });
+
+    final routing = jsonMap['routing']! as Map<String, dynamic>;
+    final rules = routing['rules']! as List<dynamic>;
+    expect(rules.single, containsPair('outboundTag', 'direct'));
+  });
+}


### PR DESCRIPTION
## Summary

- Restore Flutter's default AppBar and bottom navigation heights.
- Use the shared app logo for MSIX packaging.
- Normalize Raw JSON before validation, Real Ping, and storage so only the app-managed `pingIn` remains.
- Preserve user routing rules while rebuilding the internal ping routing rule.

## Validation

- `flutter test test/service/xray`
- `flutter analyze`
- `flutter build macos --debug`
- `git diff --check`