### PR TITLE
Configure Apple export compliance

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -26,6 +26,8 @@
 	<string>0</string>
 	<key>FlutterDeepLinkingEnabled</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -25,6 +25,8 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/macos_se/Runner/Info.plist
+++ b/macos_se/Runner/Info.plist
@@ -25,6 +25,8 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

- set `ITSAppUsesNonExemptEncryption` to `false` for iOS, macOS, and macOS SE
- declare that the Apple apps only use encryption exempt from export compliance documentation

## Validation

- `plutil -lint ios/Runner/Info.plist macos/Runner/Info.plist macos_se/Runner/Info.plist`
- `git diff --check`