### PR TITLE
Align desktop profile details to top

### DIFF
--- a/lib/pages/core/xray/full_config/page.dart
+++ b/lib/pages/core/xray/full_config/page.dart
@@ -42,6 +42,7 @@ class XrayFullConfigPage extends StatelessWidget {
                       final wide = constraints.maxWidth >= 760;
                       if (wide) {
                         return Row(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
                           children: [
                             SizedBox(
                               width: 224,

--- a/lib/pages/core/xray/profile/ui/page.dart
+++ b/lib/pages/core/xray/profile/ui/page.dart
@@ -45,6 +45,7 @@ class XrayProfileUIPage extends StatelessWidget {
                       final wide = constraints.maxWidth >= 760;
                       if (wide) {
                         return Row(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
                           children: [
                             SizedBox(
                               width: 224,

--- a/test/pages/core/xray/full_config/page_test.dart
+++ b/test/pages/core/xray/full_config/page_test.dart
@@ -68,6 +68,34 @@ void main() {
     expect(find.text('Servers'), findsOneWidget);
   });
 
+  testWidgets('desktop full config detail stays aligned to workspace top', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 1000));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    final navigation = find.byType(
+      SettingsSectionNavigation<XrayFullConfigSection>,
+    );
+    await tester.tap(
+      find.descendant(of: navigation, matching: find.text('Routing')),
+    );
+    await tester.pumpAndSettle();
+
+    final detailScroll = find.descendant(
+      of: find.byType(SettingsPageScroll),
+      matching: find.byType(SingleChildScrollView),
+    );
+    expect(detailScroll, findsOneWidget);
+    expect(
+      tester.getTopLeft(detailScroll).dy,
+      closeTo(tester.getTopLeft(navigation).dy, 0.1),
+    );
+  });
+
   testWidgets('full config uses the scrollable compact section navigation', (
     tester,
   ) async {

--- a/test/pages/core/xray/profile/ui/page_test.dart
+++ b/test/pages/core/xray/profile/ui/page_test.dart
@@ -57,6 +57,49 @@ void main() {
     expect(find.text('Edit Outbounds'), findsNothing);
   });
 
+  testWidgets('desktop profile detail stays aligned to the workspace top', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 1000));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) => ShadTheme(
+          data: ShadThemeData(
+            colorScheme: const ShadBlueColorScheme.light(),
+            radius: const BorderRadius.all(Radius.circular(8)),
+          ),
+          child: child ?? const SizedBox.shrink(),
+        ),
+        home: XrayProfileUIPage(
+          params: XrayProfileUIParams(DBConstants.defaultId),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final navigation = find.byType(
+      SettingsSectionNavigation<XrayProfileUISection>,
+    );
+    await tester.tap(
+      find.descendant(of: navigation, matching: find.text('Log')),
+    );
+    await tester.pumpAndSettle();
+
+    final detailScroll = find.descendant(
+      of: find.byType(SettingsPageScroll),
+      matching: find.byType(SingleChildScrollView),
+    );
+    expect(detailScroll, findsOneWidget);
+    expect(
+      tester.getTopLeft(detailScroll).dy,
+      closeTo(tester.getTopLeft(navigation).dy, 0.1),
+    );
+  });
+
   testWidgets('new profile uses the TUN DNS server by default', (tester) async {
     final tunSettings = TunSettingsState()..tunDnsIPv4 = '9.9.9.9';
     await tunSettings.saveToPreferences();


### PR DESCRIPTION
## Summary

- stretch the desktop workspaces in Xray Profile and Full Config to the available height
- keep short detail views aligned to the top instead of vertically centered
- add desktop regression coverage for both pages

## Why

The desktop workspace rows used the default centered cross-axis alignment. Detail sections shorter than the available height were therefore vertically centered while the navigation rail remained full height.

## Validation

- `flutter analyze`
- `flutter test` (91 tests)
- `flutter build macos --debug`
- `git diff --check`