### PR TITLE
Update Xray-core to v26.7.28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ env:
   NDK_VERSION: r29
   LIBXRAY_REF: main
   XRAY_CORE_REPOSITORY: XTLS/Xray-core
-  XRAY_CORE_REF: v26.7.11
+  XRAY_CORE_REF: v26.7.28
   BUILD_NUMBER: ${{ github.run_number }}
 
 jobs:


### PR DESCRIPTION
## Summary

- Update the App build workflow from Xray-core `v26.7.11` to `v26.7.28`.
- Keep all platform build jobs aligned through the shared `XRAY_CORE_REF` environment value.

## Validation

- `git diff --check`