### PR TITLE
android版安装后第一次连接vpn总是失败，后面就好了

### DIFF
--- a/android/app/src/main/kotlin/net/yuandev/onexray/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/yuandev/onexray/MainActivity.kt
@@ -24,6 +24,7 @@ class MainActivity : FlutterFragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
+        registerVpnStatusReceiver()
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -35,19 +36,20 @@ class MainActivity : FlutterFragmentActivity() {
         hostApi.onInit(flutterApi)
     }
 
+    // 接收器在 onCreate 中注册、onDestroy 中注销，避免在 onPause（系统弹窗导致 Activity 暂停）
+    // 期间错过 OneVpnService 发出的 VPN 状态广播，否则 Dart 侧会因收不到 CONNECTED 而超时断开。
     @SuppressLint("UnspecifiedRegisterReceiverFlag")
-    override fun onResume() {
-        super.onResume()
-        // 注册跨进程广播接收器
-        if (vpnStatusReceiver == null) {
-            vpnStatusReceiver = object : BroadcastReceiver() {
-                override fun onReceive(context: Context?, intent: Intent?) {
-                    if (intent?.action == OneVpnService.ACTION_VPN_STATUS) {
-                        val running = intent.getBooleanExtra(OneVpnService.EXTRA_RUNNING, false)
-                        XLog.d("MainActivity: received VPN status changed: $running")
-                        // 将状态交给现有 hostApi（可触发 Flutter 通知或内部状态更新）
-                        hostApi.onVpnStatusChanged(running)
-                    }
+    private fun registerVpnStatusReceiver() {
+        if (vpnStatusReceiver != null) {
+            return
+        }
+        vpnStatusReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (intent?.action == OneVpnService.ACTION_VPN_STATUS) {
+                    val running = intent.getBooleanExtra(OneVpnService.EXTRA_RUNNING, false)
+                    XLog.d("MainActivity: received VPN status changed: $running")
+                    // 将状态交给现有 hostApi（可触发 Flutter 通知或内部状态更新）
+                    hostApi.onVpnStatusChanged(running)
                 }
             }
         }
@@ -61,17 +63,6 @@ class MainActivity : FlutterFragmentActivity() {
                 registerReceiver(it, filter)
             }
         }
-    }
-
-    override fun onPause() {
-        // 解绑接收器避免泄漏
-        vpnStatusReceiver?.let {
-            try {
-                unregisterReceiver(it)
-            } catch (_: Exception) {
-            }
-        }
-        super.onPause()
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
VPN 状态广播接收器在 onResume() 中注册，在 onPause() 中注销。当 startVpn 后系统弹出 UI（ VPN 连接确认弹窗， userLeaving=true 证明了这一点）导致 Activity 暂停时，接收器被注销。此时 OneVpnService 在 Xray 启动成功后发出的 running=true 广播 被错过 ，Dart 侧永远收不到 CONNECTED 状态，等待 15 秒超时后自动调用 stopVpn ，导致第一次连接"失败"。

第二次连接时，权限已授予、没有系统弹窗，Activity 不暂停，接收器保持注册，广播被正常接收。