### PR TITLE
Fix Windows Store build and publishing integration

### DIFF
--- a/.github/workflows/publish-microsoft-store.yml
+++ b/.github/workflows/publish-microsoft-store.yml
@@ -63,7 +63,7 @@ jobs:
           echo "should_publish=false" >> "$GITHUB_OUTPUT"
 
           run_json="$(gh api "repos/${{ github.repository }}/actions/runs/$BUILD_RUN_ID")"
-          if [ "$(jq -r '.name' <<<"$run_json")" != "Build" ]; then
+          if [ "$(jq -r '.path' <<<"$run_json")" != ".github/workflows/build.yml" ]; then
             echo "Workflow run $BUILD_RUN_ID is not a Build run." >&2
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,3 +91,17 @@ Choose validation commands based on the change scope. Changes touching Pigeon, J
 4. App bar visual styling must be defined by `AppTheme.appBarTheme`. Page-level `AppBar` instances should only declare semantic content such as `title`, `leading`, `actions`, and `bottom`, unless a behavior cannot be expressed by the shared theme.
 5. Flutter UI icons must use `LucideIcons`. Do not introduce Material `Icons` or `CupertinoIcons` constants.
 6. UI typography must use `ThemeData.textTheme` or semantic styles from `AppTypography`. Page and view files must not define numeric font sizes, font families, letter spacing, or line heights directly. Code, logs, metrics, and compact labels must use their corresponding `AppTypography` styles.
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues for `OneXray/OneXray`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the five canonical triage labels. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repo. See `docs/agents/domain.md`.

--- a/build_scripts/app/windows.py
+++ b/build_scripts/app/windows.py
@@ -74,8 +74,6 @@ class WindowsBuilder(Builder):
                 "vcore-scripts",
                 "build",
                 "windows",
-                "--architecture",
-                self.target_architecture,
             ],
             cwd=vcore_dir,
         )

--- a/build_scripts/app/windows_msix.py
+++ b/build_scripts/app/windows_msix.py
@@ -199,7 +199,7 @@ def package_with_vcore(
             development_publisher=development_publisher,
         )
         run_command([makeappx, "pack", "/d", stage, "/p", rebuilt, "/o"])
-        os.replace(rebuilt, package)
+        shutil.move(rebuilt, package)
 
     if local_development:
         signtool = _sdk_tool("signtool.exe")

--- a/build_scripts/tests/test_windows_packaging.py
+++ b/build_scripts/tests/test_windows_packaging.py
@@ -95,6 +95,30 @@ class WindowsPackagingTest(unittest.TestCase):
         self.assertEqual(command[command.index("--architecture") + 1], "arm64")
         self.assertEqual(command[-1], "OneXray-windows-arm64")
 
+    def test_vcore_build_lets_vcore_detect_native_architecture(self):
+        vcore_dir = os.path.join(self.temp_dir.name, "VCore")
+        with (
+            patch.object(self.builder, "_vcore_dir", return_value=vcore_dir),
+            patch("app.windows.run_command") as run_command,
+            patch("app.windows._pe_machine", return_value=0x8664),
+            patch("app.windows.shutil.copy2"),
+        ):
+            self.builder.build_vcore()
+
+        self.assertEqual(
+            run_command.call_args_list[1].args[0],
+            [
+                "uv",
+                "run",
+                "--project",
+                os.path.join(vcore_dir, "scripts"),
+                "--locked",
+                "vcore-scripts",
+                "build",
+                "windows",
+            ],
+        )
+
     def test_msix_rejects_versions_the_store_cannot_accept(self):
         versions = ("26.8", "dev.8.5", "26.70000.5", "0.8.5")
         for version in versions:

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,29 @@
+# Domain Docs
+
+This is a single-context repository.
+
+## Before exploring
+
+- Read `CONTEXT.md` at the repository root when it exists.
+- Read ADRs under `docs/adr/` that affect the area being changed.
+
+If these files do not exist, proceed silently. The `/domain-modeling` skill creates them only when terminology or decisions need recording.
+
+## Layout
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+└── lib/
+```
+
+## Vocabulary
+
+Use domain terms as defined in `CONTEXT.md`. Avoid synonyms that its glossary explicitly rejects.
+
+If a needed concept is absent, reconsider whether it is project terminology or note the gap for `/domain-modeling`.
+
+## ADR conflicts
+
+Explicitly flag output that contradicts an existing ADR rather than silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs live in GitHub Issues for `OneXray/OneXray`. Use the `gh` CLI for all operations.
+
+Because this clone's `origin` points to `yiguo.dev`, include `--repo OneXray/OneXray` in every `gh issue` and `gh pr` command.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --repo OneXray/OneXray --title "..." --body "..."`
+- **Read an issue**: `gh issue view <number> --repo OneXray/OneXray --comments`
+- **List issues**: `gh issue list --repo OneXray/OneXray --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+- **Comment**: `gh issue comment <number> --repo OneXray/OneXray --body "..."`
+- **Apply or remove labels**: `gh issue edit <number> --repo OneXray/OneXray --add-label "..."` or `--remove-label "..."`
+- **Close**: `gh issue close <number> --repo OneXray/OneXray --comment "..."`
+
+Use a heredoc for multiline bodies.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs use the same labels and states as issues:
+
+- **Read**: `gh pr view <number> --repo OneXray/OneXray --comments` and `gh pr diff <number> --repo OneXray/OneXray`
+- **List external PRs**: `gh pr list --repo OneXray/OneXray --state open --json number,title,body,labels,author,authorAssociation,comments`, keeping only `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE`
+- **Comment, label, or close**: use the corresponding `gh pr` command with `--repo OneXray/OneXray`
+
+GitHub shares one number space across issues and PRs. Resolve a bare `#42` with `gh pr view 42 --repo OneXray/OneXray`, falling back to `gh issue view 42 --repo OneXray/OneXray`.
+
+## Skill operations
+
+- **Publish to the issue tracker**: create a GitHub issue.
+- **Fetch the relevant ticket**: run `gh issue view <number> --repo OneXray/OneXray --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The map is one issue with child issues as tickets.
+
+- **Map**: label it `wayfinder:map`.
+- **Child ticket**: link it as a GitHub sub-issue. If unavailable, add it to the map's task list and put `Part of #<map>` at the top of the child body.
+- **Child labels**: `wayfinder:research`, `wayfinder:prototype`, `wayfinder:grilling`, or `wayfinder:task`.
+- **Blocking**: use GitHub issue dependencies. If unavailable, put `Blocked by: #<n>` at the top of the child body.
+- **Frontier**: choose the first open, unassigned child without an open blocker.
+- **Claim**: `gh issue edit <number> --repo OneXray/OneXray --add-assignee @me`
+- **Resolve**: comment with the answer, close the child, then add a context pointer to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,11 @@
+# Triage Labels
+
+| Canonical role    | Tracker label     | Meaning                                  |
+| ----------------- | ----------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`    | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`      | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human` | Requires human implementation            |
+| `wontfix`         | `wontfix`         | Will not be actioned                     |
+
+When a skill mentions a canonical role, use its corresponding tracker label.


### PR DESCRIPTION
## Summary

- configure the repository's engineering-agent issue, triage, and domain conventions
- replace rebuilt Windows MSIX packages safely across runner drives
- adapt OneXray to VCore's native Windows architecture detection
- validate triggering Build runs by workflow path instead of their dynamic run name

## Validation

- `python -m unittest discover -s tests -p 'test_*.py'` (13 tests)
- VCore script tests (7 tests)
- C: to D: MSIX replacement check
- triggering Build run path checked against `.github/workflows/build.yml`
