### PR TITLE
Hide empty Local section in node lists

### DIFF
--- a/lib/core/db/dao/core_config.dart
+++ b/lib/core/db/dao/core_config.dart
@@ -54,6 +54,9 @@ class CoreConfigDao extends DatabaseAccessor<AppDatabase>
         .toList();
     final results = <ConfigQueryRow>[];
     for (final group in sortedGroups) {
+      if (group.subId == DBConstants.defaultId && group.count == 0) {
+        continue;
+      }
       results.add(group.subscription);
       if (group.subscription.subscription.expanded) {
         results.addAll(group.configs);


### PR DESCRIPTION
The Local group was always rendered in the home node list and in the outbound picker, even when it had no entries, leaving a useless collapsed header with a "0" badge. Skip the Local group in _flattenExpandedGroups when its count is zero; it reappears automatically once a local node is added because the list is driven by a drift watch stream. Subscription groups are unaffected.