### PR TITLE
feat(windows): package VCore as one application

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ env:
   NDK_VERSION: r29
   LIBXRAY_REF: main
   VCORE_REPOSITORY: ${{ github.repository_owner }}/VCore
-  VCORE_REF: d9018a2dfb75ab1f55c593023cbaa60951165eb5
+  VCORE_REF: main
   BUILD_NUMBER: ${{ github.run_number }}
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ env:
   NDK_VERSION: r29
   LIBXRAY_REF: main
   VCORE_REPOSITORY: ${{ github.repository_owner }}/VCore
-  VCORE_REF: main
+  VCORE_REF: d9018a2dfb75ab1f55c593023cbaa60951165eb5
   BUILD_NUMBER: ${{ github.run_number }}
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 OneXray App is a cross-platform Flutter Xray-core client. Supported platforms include iOS, macOS, macOS SE, Android, Windows, and Linux. Use “Multi-node Outbound（多节点出站）” for a runnable configuration source that groups multiple outbound nodes with its DNS and routing policy; avoid “Full Config”, “Multi Outbounds”, and “多出站配置”.
 
-The app manages nodes, subscriptions, Xray Profiles, Multi-node Outbounds, Raw Json configs, and GeoData. Before startup, it composes and writes the final runtime Xray JSON. Production builds use platform TUN on Android, Apple, and Linux. Packaged Windows builds use VCore's system VPN Provider and Session Host to feed a private loopback SOCKS inbound in OneXrayCore. Proxy mode is an in-memory iOS Debug-only tool.
+The app manages nodes, subscriptions, Xray Profiles, Multi-node Outbounds, Raw Json configs, and GeoData. Before startup, it composes and writes the final runtime Xray JSON. Production builds use platform TUN on Android, Apple, and Linux. Packaged Windows declares one manifest Application while retaining VCore's AppContainer VPN Provider and full-trust Session Host to feed a private loopback SOCKS inbound in OneXrayCore. Proxy mode is an in-memory iOS Debug-only tool.
 
 # Repository Layout
 

--- a/build_scripts/README.md
+++ b/build_scripts/README.md
@@ -20,7 +20,10 @@ workspace/
 └── output/        # created automatically
 ```
 
-The scripts use the currently checked-out libXray and VCore revisions. The
+The scripts use the currently checked-out libXray revision. Windows CI pins one
+immutable VCore commit for both architectures; local Windows builds must check
+out that same commit. VCore artifacts are copied only after their integration
+revision, architecture, identity, file set, and SHA-256 manifest pass. The
 Xray-core version is pinned by libXray's Go module; a sibling Xray-core checkout
 is not used.
 
@@ -114,8 +117,10 @@ workspace/
 └── output/        # 自动创建
 ```
 
-本地构建直接使用 libXray 和 VCore 当前检出的版本。Xray-core 版本由
-libXray 的 Go module 锁定，不使用同级目录下的 Xray-core checkout。
+构建使用 libXray 当前检出的版本。Windows CI 为两种架构固定同一个不可变 VCore
+commit；本地 Windows 构建必须检出同一 commit。VCore 产物只有在 integration
+revision、架构、identity、文件集合和 SHA-256 manifest 全部通过后才复制。Xray-core
+版本由 libXray 的 Go module 锁定，不使用同级目录下的 Xray-core checkout。
 
 ### 前置条件
 
@@ -202,7 +207,10 @@ workspace/
 └── output/        # создаётся автоматически
 ```
 
-При локальной сборке используются текущие версии libXray и VCore. Версия
+Сборка использует текущую версию libXray. Windows CI закрепляет один неизменяемый
+commit VCore для обеих архитектур; локальная Windows-сборка должна использовать
+тот же commit. Артефакты VCore копируются только после проверки integration
+revision, архитектуры, identity, набора файлов и SHA-256 manifest. Версия
 Xray-core закреплена Go-модулем libXray; соседний checkout Xray-core не
 используется.
 

--- a/build_scripts/README.md
+++ b/build_scripts/README.md
@@ -20,12 +20,10 @@ workspace/
 └── output/        # created automatically
 ```
 
-The scripts use the currently checked-out libXray revision. Windows CI pins one
-immutable VCore commit for both architectures; local Windows builds must check
-out that same commit. VCore artifacts are copied only after their integration
-revision, architecture, identity, file set, and SHA-256 manifest pass. The
-Xray-core version is pinned by libXray's Go module; a sibling Xray-core checkout
-is not used.
+The scripts use the currently checked-out libXray and VCore revisions. VCore
+artifacts are copied only after their integration revision, architecture,
+identity, file set, and SHA-256 manifest pass. The Xray-core version is pinned
+by libXray's Go module; a sibling Xray-core checkout is not used.
 
 ### Prerequisites
 
@@ -117,10 +115,9 @@ workspace/
 └── output/        # 自动创建
 ```
 
-构建使用 libXray 当前检出的版本。Windows CI 为两种架构固定同一个不可变 VCore
-commit；本地 Windows 构建必须检出同一 commit。VCore 产物只有在 integration
-revision、架构、identity、文件集合和 SHA-256 manifest 全部通过后才复制。Xray-core
-版本由 libXray 的 Go module 锁定，不使用同级目录下的 Xray-core checkout。
+构建使用 libXray 和 VCore 当前检出的版本。VCore 产物只有在 integration revision、
+架构、identity、文件集合和 SHA-256 manifest 全部通过后才复制。Xray-core 版本由
+libXray 的 Go module 锁定，不使用同级目录下的 Xray-core checkout。
 
 ### 前置条件
 
@@ -207,12 +204,10 @@ workspace/
 └── output/        # создаётся автоматически
 ```
 
-Сборка использует текущую версию libXray. Windows CI закрепляет один неизменяемый
-commit VCore для обеих архитектур; локальная Windows-сборка должна использовать
-тот же commit. Артефакты VCore копируются только после проверки integration
-revision, архитектуры, identity, набора файлов и SHA-256 manifest. Версия
-Xray-core закреплена Go-модулем libXray; соседний checkout Xray-core не
-используется.
+Сборка использует текущие версии libXray и VCore. Артефакты VCore копируются
+только после проверки integration revision, архитектуры, identity, набора файлов
+и SHA-256 manifest. Версия Xray-core закреплена Go-модулем libXray; соседний
+checkout Xray-core не используется.
 
 ### Требования
 

--- a/build_scripts/app/windows.py
+++ b/build_scripts/app/windows.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import os
 import shutil
 import struct
@@ -16,6 +18,9 @@ _VCORE_ARTIFACTS = (
     "vcore-windows-vpn-host.exe",
     "vcore-windows-session-host.exe",
 )
+_VCORE_IDENTITY = (
+    "VCore;engine=rust;coreVersion=0.1.0;invokeApiVersion=5;configVersion=13"
+)
 
 
 class WindowsBuilder(Builder):
@@ -27,9 +32,7 @@ class WindowsBuilder(Builder):
     ):
         super().__init__(project, system, build_scripts_dir)
         self.target_architecture = self._target_architecture()
-        package_architecture = (
-            "amd64" if self.target_architecture == "x64" else "arm64"
-        )
+        package_architecture = "amd64" if self.target_architecture == "x64" else "arm64"
         self.package_suffix = f"windows-{package_architecture}"
 
     @staticmethod
@@ -78,19 +81,12 @@ class WindowsBuilder(Builder):
             cwd=vcore_dir,
         )
 
-        source = os.path.join(
-            vcore_dir, "dist", "windows", self.target_architecture
+        source = os.path.join(vcore_dir, "dist", "windows", self.target_architecture)
+        _copy_vcore_artifacts(
+            source,
+            os.path.join(self.project_dir, "app"),
+            self.target_architecture,
         )
-        destination = os.path.join(self.project_dir, "app")
-        os.makedirs(destination, exist_ok=True)
-        expected_machine = 0x8664 if self.target_architecture == "x64" else 0xAA64
-        for name in _VCORE_ARTIFACTS:
-            artifact = os.path.join(source, name)
-            if _pe_machine(artifact) != expected_machine:
-                raise ValueError(
-                    f"VCore artifact has the wrong architecture: {artifact}"
-                )
-            shutil.copy2(artifact, destination)
 
     def _vcore_dir(self) -> str:
         configured = os.environ.get("VCORE_DIR")
@@ -129,6 +125,7 @@ class WindowsBuilder(Builder):
         package_with_vcore(
             os.path.join(self.output_dir, f"{output_name}.msix"),
             local_development=local_development,
+            certificate_thumbprint=os.environ.get("ONEXRAY_DEV_CERT_THUMBPRINT"),
             certificate_path=os.environ.get("ONEXRAY_DEV_CERT_PATH"),
             certificate_password=os.environ.get("ONEXRAY_DEV_CERT_PASSWORD"),
             development_publisher=os.environ.get("ONEXRAY_DEV_PUBLISHER"),
@@ -147,8 +144,16 @@ class WindowsBuilder(Builder):
             raise FileNotFoundError(
                 f"Windows {self.target_architecture} release bundle not found: {source}"
             )
+        # ponytail: msix 3.18 resolves the architecture twice; remove this
+        # extra directory level when upstream stops doing that.
         destination = os.path.join(
-            self.root_dir, "build", "windows", "runner", "Release"
+            self.root_dir,
+            "build",
+            "windows",
+            self.target_architecture,
+            self.target_architecture,
+            "runner",
+            "Release",
         )
         shutil.rmtree(destination, ignore_errors=True)
         shutil.copytree(source, destination)
@@ -166,6 +171,43 @@ class WindowsBuilder(Builder):
         if values[0] == 0:
             raise ValueError("MSIX major version must be greater than 0")
         return ".".join(str(value) for value in values)
+
+
+def _copy_vcore_artifacts(source: str, destination: str, architecture: str) -> None:
+    manifest_path = os.path.join(source, "vcore-windows-artifacts.json")
+    try:
+        with open(manifest_path, encoding="utf-8") as manifest_file:
+            manifest = json.load(manifest_file)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError("invalid VCore Windows artifact manifest") from error
+
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("formatVersion") != 1
+        or manifest.get("windowsPackageIntegrationRevision") != 2
+        or manifest.get("architecture") != architecture
+        or manifest.get("buildIdentity") != _VCORE_IDENTITY
+        or not isinstance(manifest.get("artifacts"), dict)
+        or set(manifest["artifacts"]) != set(_VCORE_ARTIFACTS)
+    ):
+        raise ValueError("incompatible VCore Windows artifact manifest")
+
+    expected_machine = 0x8664 if architecture == "x64" else 0xAA64
+    for name in _VCORE_ARTIFACTS:
+        artifact = os.path.join(source, name)
+        try:
+            with open(artifact, "rb") as contents:
+                digest = hashlib.file_digest(contents, "sha256").hexdigest()
+        except OSError as error:
+            raise ValueError(f"missing VCore artifact: {name}") from error
+        if digest != manifest["artifacts"][name]:
+            raise ValueError(f"VCore artifact hash mismatch: {name}")
+        if _pe_machine(artifact) != expected_machine:
+            raise ValueError(f"VCore artifact has the wrong architecture: {artifact}")
+
+    os.makedirs(destination, exist_ok=True)
+    for name in _VCORE_ARTIFACTS:
+        shutil.copy2(os.path.join(source, name), destination)
 
 
 def _pe_machine(path: str) -> int:

--- a/build_scripts/app/windows_msix.py
+++ b/build_scripts/app/windows_msix.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import tempfile
 import xml.etree.ElementTree as ET
@@ -8,6 +9,7 @@ from app.command_line import run_command
 
 _FOUNDATION = "http://schemas.microsoft.com/appx/manifest/foundation/windows10"
 _UAP = "http://schemas.microsoft.com/appx/manifest/uap/windows10"
+_UAP10 = "http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
 _DESKTOP = "http://schemas.microsoft.com/appx/manifest/desktop/windows10"
 _RESCAP = (
     "http://schemas.microsoft.com/appx/manifest/foundation/windows10/"
@@ -17,6 +19,7 @@ _RESCAP = (
 for prefix, namespace in (
     ("", _FOUNDATION),
     ("uap", _UAP),
+    ("uap10", _UAP10),
     ("desktop", _DESKTOP),
     ("rescap", _RESCAP),
 ):
@@ -41,7 +44,14 @@ def augment_manifest(
     if identity is None or applications is None or capabilities is None:
         raise ValueError("generated MSIX manifest is incomplete")
 
-    package.set("IgnorableNamespaces", "uap desktop rescap")
+    ignorable = [
+        prefix
+        for prefix in package.get("IgnorableNamespaces", "").split()
+        if prefix in {"uap", "uap10", "desktop", "rescap"}
+    ]
+    if "uap10" not in ignorable:
+        ignorable.append("uap10")
+    package.set("IgnorableNamespaces", " ".join(ignorable))
 
     if local_development:
         if not development_publisher:
@@ -49,63 +59,61 @@ def augment_manifest(
         identity.set("Name", "OneXray.Dev")
         identity.set("Publisher", development_publisher)
 
-    application_ids = {
-        app.get("Id") for app in applications.findall(_tag(_FOUNDATION, "Application"))
-    }
-    if application_ids.intersection({"SessionHost", "VpnProvider"}):
-        raise ValueError("generated MSIX manifest already contains VCore applications")
+    application_items = applications.findall(_tag(_FOUNDATION, "Application"))
+    if len(application_items) != 1:
+        raise ValueError("generated MSIX manifest must contain exactly one Application")
+    application = application_items[0]
 
-    visual_attributes = {
-        "Square150x150Logo": r"Images\Square150x150Logo.png",
-        "Square44x44Logo": r"Images\Square44x44Logo.png",
-        "BackgroundColor": "transparent",
-        "AppListEntry": "none",
+    vcore_executables = {
+        "vcore-windows-session-host.exe",
+        "vcore-windows-vpn-host.exe",
     }
+    extension_tags = {
+        _tag(_FOUNDATION, "Extension"),
+        _tag(_DESKTOP, "Extension"),
+    }
+    if (
+        any(
+            element.tag in extension_tags
+            and (
+                element.get("Executable") in vcore_executables
+                or element.get("EntryPoint") == "VCore.VpnBackgroundTask"
+            )
+            for element in package.iter()
+        )
+        or package.find(
+            f".//{_tag(_FOUNDATION, 'ActivatableClass')}"
+            "[@ActivatableClassId='VCore.VpnBackgroundTask']"
+        )
+        is not None
+    ):
+        raise ValueError("generated MSIX manifest already contains VCore extensions")
+
+    application_extensions = application.find(_tag(_FOUNDATION, "Extensions"))
+    if application_extensions is None:
+        application_extensions = ET.SubElement(
+            application,
+            _tag(_FOUNDATION, "Extensions"),
+        )
     session = ET.SubElement(
-        applications,
-        _tag(_FOUNDATION, "Application"),
+        application_extensions,
+        _tag(_DESKTOP, "Extension"),
         {
-            "Id": "SessionHost",
+            "Category": "windows.fullTrustProcess",
             "Executable": "vcore-windows-session-host.exe",
-            "EntryPoint": "Windows.FullTrustApplication",
         },
     )
-    ET.SubElement(
-        session,
-        _tag(_UAP, "VisualElements"),
-        {
-            **visual_attributes,
-            "DisplayName": "OneXray VPN Session Host",
-            "Description": "OneXray VPN session host",
-        },
-    )
+    ET.SubElement(session, _tag(_DESKTOP, "FullTrustProcess"))
 
-    provider = ET.SubElement(
-        applications,
-        _tag(_FOUNDATION, "Application"),
-        {
-            "Id": "VpnProvider",
-            "Executable": "vcore-windows-vpn-host.exe",
-            "EntryPoint": "VCore.VpnHost.App",
-        },
-    )
-    ET.SubElement(
-        provider,
-        _tag(_UAP, "VisualElements"),
-        {
-            **visual_attributes,
-            "DisplayName": "OneXray VPN Provider",
-            "Description": "OneXray VPN provider",
-        },
-    )
-    provider_extensions = ET.SubElement(provider, _tag(_FOUNDATION, "Extensions"))
     background = ET.SubElement(
-        provider_extensions,
+        application_extensions,
         _tag(_FOUNDATION, "Extension"),
         {
             "Category": "windows.backgroundTasks",
             "Executable": "vcore-windows-vpn-host.exe",
             "EntryPoint": "VCore.VpnBackgroundTask",
+            _tag(_UAP10, "RuntimeBehavior"): "windowsApp",
+            _tag(_UAP10, "TrustLevel"): "appContainer",
         },
     )
     tasks = ET.SubElement(background, _tag(_FOUNDATION, "BackgroundTasks"))
@@ -143,7 +151,8 @@ def augment_manifest(
     capability_names = {
         element.get("Name")
         for element in capabilities
-        if element.tag in {
+        if element.tag
+        in {
             _tag(_FOUNDATION, "Capability"),
             _tag(_RESCAP, "Capability"),
         }
@@ -167,20 +176,30 @@ def package_with_vcore(
     package: str,
     *,
     local_development: bool = False,
+    certificate_thumbprint: str | None = None,
     certificate_path: str | None = None,
     certificate_password: str | None = None,
     development_publisher: str | None = None,
 ) -> None:
-    if local_development and (
-        not certificate_path
-        or not os.path.isfile(certificate_path)
-        or not certificate_password
-        or not development_publisher
-    ):
-        raise ValueError(
-            "ONEXRAY_DEV_CERT_PATH, ONEXRAY_DEV_CERT_PASSWORD, and "
-            "ONEXRAY_DEV_PUBLISHER are required"
-        )
+    if local_development:
+        if not development_publisher:
+            raise ValueError("ONEXRAY_DEV_PUBLISHER is required")
+        if certificate_thumbprint:
+            certificate_thumbprint = re.sub(r"\s", "", certificate_thumbprint).upper()
+            if not re.fullmatch(r"[0-9A-F]{40}", certificate_thumbprint):
+                raise ValueError(
+                    "ONEXRAY_DEV_CERT_THUMBPRINT must contain exactly "
+                    "40 hexadecimal characters"
+                )
+        elif (
+            not certificate_path
+            or not os.path.isfile(certificate_path)
+            or not certificate_password
+        ):
+            raise ValueError(
+                "ONEXRAY_DEV_CERT_THUMBPRINT or ONEXRAY_DEV_CERT_PATH and "
+                "ONEXRAY_DEV_CERT_PASSWORD are required"
+            )
     makeappx = _sdk_tool("makeappx.exe")
     with tempfile.TemporaryDirectory(prefix="onexray-msix-") as temporary:
         stage = os.path.join(temporary, "stage")
@@ -203,20 +222,14 @@ def package_with_vcore(
 
     if local_development:
         signtool = _sdk_tool("signtool.exe")
-        run_command(
-            [
-                signtool,
-                "sign",
-                "/fd",
-                "SHA256",
-                "/f",
-                certificate_path,
-                "/p",
-                certificate_password,
-                package,
-            ],
-            redact=True,
-        )
+        sign_command = [signtool, "sign", "/fd", "SHA256"]
+        if certificate_thumbprint:
+            sign_command.extend(["/sha1", certificate_thumbprint, "/s", "My", package])
+        else:
+            sign_command.extend(
+                ["/f", certificate_path, "/p", certificate_password, package]
+            )
+        run_command(sign_command, redact=True)
         run_command([signtool, "verify", "/pa", package])
 
 
@@ -227,7 +240,9 @@ def _sdk_tool(name: str) -> str:
     if not program_files:
         raise FileNotFoundError(f"{name} was not found")
     matches = sorted(
-        glob(os.path.join(program_files, "Windows Kits", "10", "bin", "*", "x64", name)),
+        glob(
+            os.path.join(program_files, "Windows Kits", "10", "bin", "*", "x64", name)
+        ),
         reverse=True,
     )
     if not matches:

--- a/build_scripts/tests/test_windows_packaging.py
+++ b/build_scripts/tests/test_windows_packaging.py
@@ -1,10 +1,13 @@
+import hashlib
+import json
 import os
 import tempfile
 import unittest
 import xml.etree.ElementTree as ET
+from pathlib import Path
 from unittest.mock import patch
 
-from app.windows import WindowsBuilder
+from app.windows import WindowsBuilder, _copy_vcore_artifacts
 from app.windows_msix import augment_manifest, package_with_vcore
 
 
@@ -17,11 +20,7 @@ class WindowsPackagingTest(unittest.TestCase):
         os.makedirs(self.project_dir)
         self.pubspec_path = os.path.join(self.temp_dir.name, "pubspec.yaml")
         with open(self.pubspec_path, mode="wb") as f:
-            f.write(
-                b"name: OneXray\n"
-                b"description: Test fixture\n"
-                b"version: 26.7.3+412\n"
-            )
+            f.write(b"name: OneXray\ndescription: Test fixture\nversion: 26.7.3+412\n")
 
         self.builder = WindowsBuilder.__new__(WindowsBuilder)
         self.builder.project = "OneXray"
@@ -75,6 +74,7 @@ class WindowsPackagingTest(unittest.TestCase):
                 "OneXray-windows-amd64.msix",
             ),
             local_development=False,
+            certificate_thumbprint=None,
             certificate_path=None,
             certificate_password=None,
             development_publisher=None,
@@ -100,8 +100,7 @@ class WindowsPackagingTest(unittest.TestCase):
         with (
             patch.object(self.builder, "_vcore_dir", return_value=vcore_dir),
             patch("app.windows.run_command") as run_command,
-            patch("app.windows._pe_machine", return_value=0x8664),
-            patch("app.windows.shutil.copy2"),
+            patch("app.windows._copy_vcore_artifacts") as copy_vcore_artifacts,
         ):
             self.builder.build_vcore()
 
@@ -118,6 +117,42 @@ class WindowsPackagingTest(unittest.TestCase):
                 "windows",
             ],
         )
+        copy_vcore_artifacts.assert_called_once_with(
+            os.path.join(vcore_dir, "dist", "windows", "x64"),
+            os.path.join(self.project_dir, "app"),
+            "x64",
+        )
+
+    def test_prepare_msix_bundle_stages_path_resolved_by_msix_3_18(self):
+        self.builder.target_architecture = "arm64"
+        source = os.path.join(
+            self.temp_dir.name,
+            "build",
+            "windows",
+            "arm64",
+            "runner",
+            "Release",
+        )
+        os.makedirs(source)
+        with open(os.path.join(source, "OneXray.exe"), "wb") as executable:
+            executable.write(b"app")
+
+        WindowsBuilder._prepare_msix_bundle(self.builder)
+
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.temp_dir.name,
+                    "build",
+                    "windows",
+                    "arm64",
+                    "arm64",
+                    "runner",
+                    "Release",
+                    "OneXray.exe",
+                )
+            )
+        )
 
     def test_msix_rejects_versions_the_store_cannot_accept(self):
         versions = ("26.8", "dev.8.5", "26.70000.5", "0.8.5")
@@ -131,6 +166,20 @@ class WindowsPackagingTest(unittest.TestCase):
         with patch.dict(os.environ, {"ONEXRAY_WINDOWS_ARCH": "arm64"}):
             self.assertEqual(WindowsBuilder._target_architecture(), "arm64")
 
+    def test_windows_jobs_pin_and_record_one_vcore_commit(self):
+        workflow = (
+            Path(__file__).resolve().parents[2] / ".github/workflows/build.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "VCORE_REF: d9018a2dfb75ab1f55c593023cbaa60951165eb5",
+            workflow,
+        )
+        self.assertNotIn("VCORE_REF: main", workflow)
+        self.assertIn(
+            'echo "${VCORE_REF}" > release-metadata/vcore-sha.txt',
+            workflow,
+        )
+
     def test_local_signing_requires_certificate_and_publisher(self):
         with self.assertRaises(ValueError):
             package_with_vcore(
@@ -140,39 +189,213 @@ class WindowsPackagingTest(unittest.TestCase):
                 certificate_password="test",
                 development_publisher="CN=OneXray Development",
             )
+        with self.assertRaisesRegex(ValueError, "40 hexadecimal"):
+            package_with_vcore(
+                "missing.msix",
+                local_development=True,
+                certificate_thumbprint="invalid",
+                development_publisher="CN=OneXray Development",
+            )
 
-    def test_manifest_adds_vcore_hosts_and_activation(self):
+    def test_vcore_artifact_manifest_is_verified_before_copying(self):
+        source = os.path.join(self.temp_dir.name, "vcore")
+        destination = os.path.join(self.project_dir, "app")
+        _write_vcore_set(source)
+
+        _copy_vcore_artifacts(source, destination, "x64")
+
+        for name in _VCORE_ARTIFACTS:
+            self.assertTrue(os.path.isfile(os.path.join(destination, name)))
+
+    def test_vcore_artifact_manifest_rejects_incompatible_sets(self):
+        mutations = {
+            "revision": lambda manifest: manifest.update(
+                windowsPackageIntegrationRevision=1
+            ),
+            "architecture": lambda manifest: manifest.update(architecture="arm64"),
+            "identity": lambda manifest: manifest.update(buildIdentity="old"),
+            "file set": lambda manifest: manifest["artifacts"].pop(
+                "vcore-windows-session-host.exe"
+            ),
+            "hash": lambda manifest: manifest["artifacts"].update(
+                {"vcore.dll": "0" * 64}
+            ),
+        }
+        for name, mutate in mutations.items():
+            with self.subTest(name=name):
+                source = os.path.join(self.temp_dir.name, name.replace(" ", "-"))
+                manifest = _write_vcore_set(source)
+                mutate(manifest)
+                _write_manifest(source, manifest)
+                with self.assertRaises(ValueError):
+                    _copy_vcore_artifacts(
+                        source,
+                        os.path.join(self.project_dir, "app"),
+                        "x64",
+                    )
+
+    def test_store_and_local_manifests_have_one_application_contract(self):
+        for local_development in (False, True):
+            with self.subTest(local_development=local_development):
+                manifest = os.path.join(
+                    self.temp_dir.name,
+                    f"AppxManifest-{local_development}.xml",
+                )
+                with open(manifest, "w", encoding="utf-8") as output:
+                    output.write(_MANIFEST_FIXTURE)
+
+                augment_manifest(
+                    manifest,
+                    local_development=local_development,
+                    development_publisher="CN=OneXray Development",
+                )
+
+                root = ET.parse(manifest).getroot()
+                ns = {
+                    "f": _FOUNDATION,
+                    "uap": _UAP,
+                    "uap10": _UAP10,
+                    "desktop": _DESKTOP,
+                }
+                identity = root.find("f:Identity", ns)
+                self.assertEqual(
+                    identity.attrib["Name"],
+                    "OneXray.Dev" if local_development else "YuanDevLLC.OneXray",
+                )
+                self.assertEqual(
+                    identity.attrib["Publisher"],
+                    "CN=OneXray Development" if local_development else "CN=Store",
+                )
+                ignorable = root.attrib["IgnorableNamespaces"].split()
+                self.assertIn("uap10", ignorable)
+                self.assertNotIn("uap3", ignorable)
+
+                applications = root.findall("f:Applications/f:Application", ns)
+                self.assertEqual(len(applications), 1)
+                application = applications[0]
+                self.assertEqual(application.attrib["Id"], "OneXray")
+                self.assertEqual(application.attrib["Executable"], "OneXray.exe")
+                self.assertFalse(
+                    any("AppListEntry" in element.attrib for element in root.iter())
+                )
+
+                session = application.find(
+                    "f:Extensions/desktop:Extension"
+                    "[@Category='windows.fullTrustProcess']",
+                    ns,
+                )
+                self.assertEqual(
+                    session.attrib["Executable"],
+                    "vcore-windows-session-host.exe",
+                )
+                self.assertIsNotNone(session.find("desktop:FullTrustProcess", ns))
+
+                provider = application.find(
+                    "f:Extensions/f:Extension[@Category='windows.backgroundTasks']",
+                    ns,
+                )
+                self.assertEqual(
+                    provider.attrib["Executable"],
+                    "vcore-windows-vpn-host.exe",
+                )
+                self.assertEqual(
+                    provider.attrib["EntryPoint"],
+                    "VCore.VpnBackgroundTask",
+                )
+                self.assertEqual(
+                    provider.attrib[f"{{{_UAP10}}}RuntimeBehavior"],
+                    "windowsApp",
+                )
+                self.assertEqual(
+                    provider.attrib[f"{{{_UAP10}}}TrustLevel"],
+                    "appContainer",
+                )
+                self.assertIsNotNone(
+                    provider.find("f:BackgroundTasks/uap:Task[@Type='vpnClient']", ns)
+                )
+                self.assertIsNotNone(
+                    application.find(
+                        "f:Extensions/uap:Extension[@Category='windows.protocol']"
+                        "/uap:Protocol[@Name='onexray']",
+                        ns,
+                    )
+                )
+                startup = application.find(
+                    "f:Extensions/desktop:Extension[@Category='windows.startupTask']"
+                    "/desktop:StartupTask",
+                    ns,
+                )
+                self.assertEqual(startup.attrib["TaskId"], "VCoreStartup")
+                self.assertEqual(startup.attrib["Enabled"], "false")
+                self.assertEqual(
+                    root.find(".//f:InProcessServer/f:Path", ns).text,
+                    "vcore.dll",
+                )
+
+    def test_manifest_rejects_duplicate_vcore_extensions(self):
         manifest = os.path.join(self.temp_dir.name, "AppxManifest.xml")
         with open(manifest, "w", encoding="utf-8") as output:
             output.write(_MANIFEST_FIXTURE)
+        augment_manifest(manifest)
 
-        augment_manifest(
-            manifest,
-            local_development=True,
-            development_publisher="CN=OneXray Development",
-        )
+        with self.assertRaises(ValueError):
+            augment_manifest(manifest)
 
-        root = ET.parse(manifest).getroot()
-        ns = {"f": _FOUNDATION}
-        identity = root.find("f:Identity", ns)
-        self.assertEqual(identity.attrib["Name"], "OneXray.Dev")
-        self.assertEqual(identity.attrib["Publisher"], "CN=OneXray Development")
-        self.assertIsNotNone(root.find(".//f:Application[@Id='SessionHost']", ns))
-        self.assertIsNotNone(root.find(".//f:Application[@Id='VpnProvider']", ns))
-        self.assertEqual(
-            root.find(".//f:InProcessServer/f:Path", ns).text,
-            "vcore.dll",
-        )
+
+_VCORE_ARTIFACTS = (
+    "vcore.dll",
+    "vcore-windows-vpn-host.exe",
+    "vcore-windows-session-host.exe",
+)
+_VCORE_IDENTITY = (
+    "VCore;engine=rust;coreVersion=0.1.0;invokeApiVersion=5;configVersion=13"
+)
+
+
+def _write_vcore_set(path):
+    os.makedirs(path)
+    hashes = {}
+    for name in _VCORE_ARTIFACTS:
+        artifact = os.path.join(path, name)
+        contents = bytearray(0x86)
+        contents[:2] = b"MZ"
+        contents[0x3C:0x40] = (0x80).to_bytes(4, "little")
+        contents[0x80:0x84] = b"PE\0\0"
+        contents[0x84:0x86] = (0x8664).to_bytes(2, "little")
+        with open(artifact, "wb") as output:
+            output.write(contents)
+        hashes[name] = hashlib.sha256(contents).hexdigest()
+    manifest = {
+        "formatVersion": 1,
+        "windowsPackageIntegrationRevision": 2,
+        "architecture": "x64",
+        "buildIdentity": _VCORE_IDENTITY,
+        "artifacts": hashes,
+    }
+    _write_manifest(path, manifest)
+    return manifest
+
+
+def _write_manifest(path, manifest):
+    with open(
+        os.path.join(path, "vcore-windows-artifacts.json"),
+        "w",
+        encoding="utf-8",
+    ) as output:
+        json.dump(manifest, output)
 
 
 _FOUNDATION = "http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+_UAP = "http://schemas.microsoft.com/appx/manifest/uap/windows10"
+_UAP10 = "http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
 _DESKTOP = "http://schemas.microsoft.com/appx/manifest/desktop/windows10"
 _MANIFEST_FIXTURE = f'''<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="{_FOUNDATION}"
  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+ xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
  xmlns:desktop="{_DESKTOP}"
  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
- IgnorableNamespaces="uap desktop rescap">
+ IgnorableNamespaces="uap uap3 desktop rescap">
  <Identity Name="YuanDevLLC.OneXray" Publisher="CN=Store" Version="1.0.0.0" ProcessorArchitecture="x64" />
  <Capabilities>
   <Capability Name="internetClientServer" />
@@ -183,6 +406,9 @@ _MANIFEST_FIXTURE = f'''<?xml version="1.0" encoding="utf-8"?>
  <Applications>
   <Application Id="OneXray" Executable="OneXray.exe" EntryPoint="Windows.FullTrustApplication">
    <Extensions>
+    <uap:Extension Category="windows.protocol">
+     <uap:Protocol Name="onexray" />
+    </uap:Extension>
     <desktop:Extension Category="windows.startupTask" Executable="OneXray.exe" EntryPoint="Windows.FullTrustApplication">
      <desktop:StartupTask TaskId="VCoreStartup" Enabled="false" DisplayName="OneXray" />
     </desktop:Extension>

--- a/build_scripts/tests/test_windows_packaging.py
+++ b/build_scripts/tests/test_windows_packaging.py
@@ -7,7 +7,12 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from unittest.mock import patch
 
-from app.windows import WindowsBuilder, _copy_vcore_artifacts
+from app.windows import (
+    WindowsBuilder,
+    _copy_vcore_artifacts,
+    _VCORE_ARTIFACTS,
+    _VCORE_IDENTITY,
+)
 from app.windows_msix import augment_manifest, package_with_vcore
 
 
@@ -336,16 +341,6 @@ class WindowsPackagingTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             augment_manifest(manifest)
-
-
-_VCORE_ARTIFACTS = (
-    "vcore.dll",
-    "vcore-windows-vpn-host.exe",
-    "vcore-windows-session-host.exe",
-)
-_VCORE_IDENTITY = (
-    "VCore;engine=rust;coreVersion=0.1.0;invokeApiVersion=5;configVersion=13"
-)
 
 
 def _write_vcore_set(path):

--- a/build_scripts/tests/test_windows_packaging.py
+++ b/build_scripts/tests/test_windows_packaging.py
@@ -166,15 +166,11 @@ class WindowsPackagingTest(unittest.TestCase):
         with patch.dict(os.environ, {"ONEXRAY_WINDOWS_ARCH": "arm64"}):
             self.assertEqual(WindowsBuilder._target_architecture(), "arm64")
 
-    def test_windows_jobs_pin_and_record_one_vcore_commit(self):
+    def test_windows_jobs_track_and_record_vcore_main(self):
         workflow = (
             Path(__file__).resolve().parents[2] / ".github/workflows/build.yml"
         ).read_text(encoding="utf-8")
-        self.assertIn(
-            "VCORE_REF: d9018a2dfb75ab1f55c593023cbaa60951165eb5",
-            workflow,
-        )
-        self.assertNotIn("VCORE_REF: main", workflow)
+        self.assertIn("VCORE_REF: main", workflow)
         self.assertIn(
             'echo "${VCORE_REF}" > release-metadata/vcore-sha.txt',
             workflow,

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -4,7 +4,7 @@ Windows 构建以 [`.github/workflows/build.yml`](../.github/workflows/build.yml
 
 ## CI 构建
 
-Windows 的构建矩阵、runner 标签、工具链安装步骤和 artifact 名称直接查看 [Build workflow](../.github/workflows/build.yml)。两个架构都从同一组 OneXray、libXray 和 VCore 源码构建；Xray-core 版本由 libXray 的 Go module 锁定，最终只输出 Microsoft Store MSIX 分发包。
+Windows 的构建矩阵、runner 标签、工具链安装步骤和 artifact 名称直接查看 [Build workflow](../.github/workflows/build.yml)。x64 与 ARM64 job 使用同一个不可变 VCore commit，release metadata 记录该真实 SHA；Xray-core 版本由 libXray 的 Go module 锁定，最终只输出 Microsoft Store MSIX 分发包。
 
 [`publish-microsoft-store.yml`](../.github/workflows/publish-microsoft-store.yml) 将两个架构的 MSIX 合并为 MSIX Bundle；release tag 构建会继续提交到 Microsoft Partner Center，手动构建只生成 Bundle。
 
@@ -15,10 +15,11 @@ Windows 的构建矩阵、runner 标签、工具链安装步骤和 artifact 名�
 - Windows CMake 工程使用 C++17。
 - MSVC 编译启用 `/W4 /WX`，警告会导致构建失败。
 - Flutter、Go、libXray 生成的 `OneXrayCore.exe` 和三个 VCore 产物的架构必须与矩阵项一致。
-- MSIX 最低系统版本为 Windows 10 20H2（build 19042），包含完全信任前台 App、隐藏 Session Host 和 AppContainer VPN Provider。
-- VCore Provider 将系统 IP 包交给 Session Host；Session Host 用一个 kill-on-close Job Object 启动并监督普通权限 `OneXrayCore.exe`，VCore 再通过无认证的动态 loopback SOCKS5 转发。`sessionBackend` 只管理进程存活，不检查端口或 readiness；该 SOCKS5 仅监听 `127.0.0.1`，不是用户代理入口。
-- MSIX 声明 `networkingVpnProvider`、网络和 `runFullTrust` 能力，注册 `VCore.VpnBackgroundTask` 及默认关闭的 `VCoreStartup`。Core 不使用 `allowElevation`。
-- `msix:create` 生成基础包后，`build_scripts/app/windows_msix.py` 只补充其无法表达的 VCore Application 和 in-process server，再由 `makeappx` 原路径重打包。
+- MSIX 最低系统版本为 Windows 10 20H2（build 19042），只声明一个主 Application，但保留完全信任前台、AppContainer VPN Provider 和 full-trust Session Host 三个进程。
+- Provider 通过无参数 `FullTrustProcessLauncher` 启动 Session Host。VCore Provider 将系统 IP 包交给 Session Host；Session Host 用 kill-on-close Job Object 启动并监督普通权限 `OneXrayCore.exe`，VCore 再通过动态 loopback SOCKS5 转发。`sessionBackend` 只管理进程存活，不检查端口或 readiness；该 SOCKS5 仅监听 `127.0.0.1`，不是用户代理入口。
+- MSIX 声明 `networkingVpnProvider`、网络和 `runFullTrust` 能力，注册 `VCore.VpnBackgroundTask` 及默认关闭的 `VCoreStartup`。Provider extension 显式保持 `windowsApp` / `appContainer`，Session Host extension 保持 `packagedClassicApp` / `mediumIL`。Core 不使用 `allowElevation`。
+- `msix:create` 生成基础包后，`build_scripts/app/windows_msix.py` 把两个 VCore extension 放入现有主 Application，并补充 package-level in-process server，再由 `makeappx` 原路径重打包。已有 VCore extension 或 Application 数量不为一时直接失败。
+- VCore 构建输出必须附带 artifact manifest；复制前校验 package integration revision 2、架构、config schema revision 13、三项文件集合和全部 SHA-256。任一不匹配都在打包前失败。
 - 完成构建和打包后、上传产物前执行 `OneXrayCore.exe -h`，用于发现无法加载或架构错误。
 - workflow 中的注释、runner 标签和实际构建步骤必须同步；外部调研结论不替代 GitHub Actions 实机结果。
 
@@ -31,15 +32,15 @@ Windows 的构建矩阵、runner 标签、工具链安装步骤和 artifact 名�
 3. `/W4 /WX` 下没有新增告警。
 4. 生成的 Core 可执行文件能够运行帮助命令。
 5. 两个架构的 MSIX 和上传产物名称正确，且不再生成 ZIP 或 EXE 安装包。
-6. Manifest 包含三个 Application、VCore activation class、所需能力和 `VCoreStartup`；包内三个 VCore 文件均为目标架构。
+6. Manifest 恰好包含一个 Application、两个 VCore extension、VCore activation class、所需能力和 `VCoreStartup`；没有 helper Id 或 `AppListEntry`，包内三个 VCore 文件均为目标架构且 hash 与 artifact manifest 一致。
 7. MSIX 不包含 `allowElevation`，Core 启动不触发 UAC。
 8. Microsoft Store workflow 能从两个架构的 MSIX artifact 生成 MSIX Bundle；实际发布必须另行验证 Partner Center 凭据和受限能力审批。
 
 ## 本地签名包
 
-本地测试继续走同一 `msix:create` 和 manifest 增强流程。设置 `ONEXRAY_DEV_SIGN=1`、`ONEXRAY_DEV_CERT_PATH`、`ONEXRAY_DEV_CERT_PASSWORD` 和与 PFX Subject 一致的 `ONEXRAY_DEV_PUBLISHER` 后，构建脚本将开发包身份改为 `OneXray.Dev`，使用指定 PFX 签名并调用 `signtool verify`。脚本不会生成、导入或删除证书。
+本地测试继续走同一 `msix:create` 和 manifest 增强流程。设置 `ONEXRAY_DEV_SIGN=1`、`ONEXRAY_DEV_CERT_THUMBPRINT` 和与证书 Subject 一致的 `ONEXRAY_DEV_PUBLISHER` 后，构建脚本将开发包身份改为 `OneXray.Dev`，从 `Cert:\CurrentUser\My` 选择已安装私钥并调用 `signtool verify`。CI 仍可改用 `ONEXRAY_DEV_CERT_PATH` 与 `ONEXRAY_DEV_CERT_PASSWORD`。打包脚本不会生成、导入或删除证书。此工作区的固定本地证书由 `../references/windows-development-certificate/install.ps1` 一次性安装。
 
-开发包与 Partner Center 包身份不同，不能互相原位升级。安装、更新或卸载测试必须先停止活动 VPN。EXE/ZIP 版本不属于 MSIX 升级来源，不执行配置、登录项或数据迁移。
+开发阶段只验证目标版本清洁安装。测试前停止活动 VPN，卸载旧开发包并删除测试 profile、LocalState、Snapshot 和测试数据库；不执行原位升级、降级、旧数据保留或协议互通测试。脚本不包含旧 revision decoder、迁移或 fallback。
 
 本地不必伪造 GitHub 托管镜像。涉及镜像可用性、预装软件或标签变更时，以 GitHub 官方 runner image 清单和实际 workflow run 为准。
 

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -4,7 +4,7 @@ Windows 构建以 [`.github/workflows/build.yml`](../.github/workflows/build.yml
 
 ## CI 构建
 
-Windows 的构建矩阵、runner 标签、工具链安装步骤和 artifact 名称直接查看 [Build workflow](../.github/workflows/build.yml)。x64 与 ARM64 job 使用同一个不可变 VCore commit，release metadata 记录该真实 SHA；Xray-core 版本由 libXray 的 Go module 锁定，最终只输出 Microsoft Store MSIX 分发包。
+Windows 的构建矩阵、runner 标签、工具链安装步骤和 artifact 名称直接查看 [Build workflow](../.github/workflows/build.yml)。x64 与 ARM64 job 都从 VCore 的 `main` 分支构建；Xray-core 版本由 libXray 的 Go module 锁定，最终只输出 Microsoft Store MSIX 分发包。
 
 [`publish-microsoft-store.yml`](../.github/workflows/publish-microsoft-store.yml) 将两个架构的 MSIX 合并为 MSIX Bundle；release tag 构建会继续提交到 Microsoft Partner Center，手动构建只生成 Bundle。
 

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -4,7 +4,7 @@ Windows 构建以 [`.github/workflows/build.yml`](../.github/workflows/build.yml
 
 ## CI 构建
 
-Windows 的构建矩阵、runner 标签、工具链安装步骤和 artifact 名称直接查看 [Build workflow](../.github/workflows/build.yml)。x64 与 ARM64 job 都从 VCore 的 `main` 分支构建；Xray-core 版本由 libXray 的 Go module 锁定，最终只输出 Microsoft Store MSIX 分发包。
+Windows 的构建矩阵、依赖 revision、runner 标签、工具链安装步骤和 artifact 名称直接查看 [Build workflow](../.github/workflows/build.yml)。Xray-core 版本由 libXray 的 Go module 锁定，最终只输出 Microsoft Store MSIX 分发包。
 
 [`publish-microsoft-store.yml`](../.github/workflows/publish-microsoft-store.yml) 将两个架构的 MSIX 合并为 MSIX Bundle；release tag 构建会继续提交到 Microsoft Partner Center，手动构建只生成 Bundle。
 
@@ -38,7 +38,34 @@ Windows 的构建矩阵、runner 标签、工具链安装步骤和 artifact 名�
 
 ## 本地签名包
 
-本地测试继续走同一 `msix:create` 和 manifest 增强流程。设置 `ONEXRAY_DEV_SIGN=1`、`ONEXRAY_DEV_CERT_THUMBPRINT` 和与证书 Subject 一致的 `ONEXRAY_DEV_PUBLISHER` 后，构建脚本将开发包身份改为 `OneXray.Dev`，从 `Cert:\CurrentUser\My` 选择已安装私钥并调用 `signtool verify`。CI 仍可改用 `ONEXRAY_DEV_CERT_PATH` 与 `ONEXRAY_DEV_CERT_PASSWORD`。打包脚本不会生成、导入或删除证书。此工作区的固定本地证书由 `../references/windows-development-certificate/install.ps1` 一次性安装。
+本地测试继续走同一 `msix:create` 和 manifest 增强流程。使用带 Code Signing EKU（`1.3.6.1.5.5.7.3.3`）和私钥的开发证书，将 PFX 导入当前用户证书库：
+
+```powershell
+$pfxPath = "C:\path\development.pfx"
+$password = Read-Host "PFX password" -AsSecureString
+$certificate = Import-PfxCertificate `
+    -FilePath $pfxPath `
+    -Password $password `
+    -CertStoreLocation "Cert:\CurrentUser\My"
+```
+
+自签名证书还需仅在测试机上信任其公开 CER；第二条命令需要管理员 PowerShell：
+
+```powershell
+$cerPath = "C:\path\development.cer"
+Import-Certificate -FilePath $cerPath -CertStoreLocation "Cert:\CurrentUser\Root"
+Import-Certificate -FilePath $cerPath -CertStoreLocation "Cert:\LocalMachine\TrustedPeople"
+```
+
+在执行构建的 PowerShell 中选择该证书：
+
+```powershell
+$env:ONEXRAY_DEV_SIGN = "1"
+$env:ONEXRAY_DEV_CERT_THUMBPRINT = $certificate.Thumbprint
+$env:ONEXRAY_DEV_PUBLISHER = $certificate.Subject
+```
+
+构建脚本将开发包身份改为 `OneXray.Dev`，从 `Cert:\CurrentUser\My` 选择已安装私钥，并调用 `signtool verify`。CI 仍可改用 `ONEXRAY_DEV_CERT_PATH` 与 `ONEXRAY_DEV_CERT_PASSWORD`。打包脚本不会生成、导入或删除证书。
 
 开发阶段只验证目标版本清洁安装。测试前停止活动 VPN，卸载旧开发包并删除测试 profile、LocalState、Snapshot 和测试数据库；不执行原位升级、降级、旧数据保留或协议互通测试。脚本不包含旧 revision decoder、迁移或 fallback。
 


### PR DESCRIPTION
## Summary
- keep the VCore VPN provider and session host extensions under the single generated MSIX application
- validate VCore artifacts by integration revision, architecture, identity, file set, and SHA-256 while continuing to track `VCORE_REF: main`
- support local certificate-store signing and document the updated Windows packaging flow

## Tests
- `cd build_scripts && python -m unittest tests.test_windows_packaging`