### PR TITLE
Fix no response when sharing a backup

### DIFF
--- a/lib/pages/core/log/config_file_viewer/controller.dart
+++ b/lib/pages/core/log/config_file_viewer/controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:onexray/pages/mixin/page_cubit.dart';
 import 'package:onexray/l10n/localizations/app_localizations.dart';
 import 'package:onexray/pages/mixin/alert.dart';
+import 'package:onexray/pages/mixin/share.dart';
 import 'package:onexray/pages/core/log/config_file_viewer/params.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -43,44 +44,27 @@ class ConfigFileViewerController extends PageCubit<ConfigFileViewerPageState> {
   }
 
   Future<void> shareFile(BuildContext context) async {
-    Rect? sharePositionOrigin;
-    if (context.mounted) {
-      final box = context.findRenderObject() as RenderBox?;
-      if (box != null) {
-        sharePositionOrigin = box.localToGlobal(Offset.zero) & box.size;
-      }
-    }
+    final sharePositionOrigin = ContextShare.positionOrigin(context);
 
     final file = File(params.path);
     if (await file.exists()) {
-      final name = this.params.title;
-      final params = ShareParams(
-        files: [XFile(file.path)],
-        fileNameOverrides: [name],
-        sharePositionOrigin: sharePositionOrigin,
+      final outcome = await ContextShare.share(
+        ShareParams(
+          files: [XFile(file.path)],
+          fileNameOverrides: [params.title],
+          sharePositionOrigin: sharePositionOrigin,
+        ),
       );
-      final result = await SharePlus.instance.share(params);
-
-      if (result.status == ShareResultStatus.success) {
-        if (context.mounted) {
-          ContextAlert.showToast(
-            context,
-            AppLocalizations.of(context)!.actionResult(
-              AppLocalizations.of(context)!.configFileViewerPageShare,
-              AppLocalizations.of(context)!.resultSuccess,
-            ),
-          );
-        }
-      } else {
-        if (context.mounted) {
-          ContextAlert.showToast(
-            context,
-            AppLocalizations.of(context)!.actionResult(
-              AppLocalizations.of(context)!.configFileViewerPageShare,
-              AppLocalizations.of(context)!.resultFailed,
-            ),
-          );
-        }
+      if (context.mounted && outcome != ShareOutcome.unconfirmed) {
+        ContextAlert.showToast(
+          context,
+          AppLocalizations.of(context)!.actionResult(
+            AppLocalizations.of(context)!.configFileViewerPageShare,
+            outcome == ShareOutcome.success
+                ? AppLocalizations.of(context)!.resultSuccess
+                : AppLocalizations.of(context)!.resultFailed,
+          ),
+        );
       }
     } else {
       if (context.mounted) {

--- a/lib/pages/core/main/controller.dart
+++ b/lib/pages/core/main/controller.dart
@@ -9,6 +9,7 @@ import 'package:onexray/pages/core/geo_data/list/params.dart';
 import 'package:onexray/pages/core/log/config_file_viewer/params.dart';
 import 'package:onexray/pages/core/log/log_file_viewer/params.dart';
 import 'package:onexray/pages/main/navigation.dart';
+import 'package:onexray/pages/mixin/share.dart';
 import 'package:onexray/pages/widget/menu_picker.dart';
 import 'package:onexray/service/core_run_mode/state.dart';
 import 'package:onexray/service/vpn/service.dart';
@@ -94,14 +95,8 @@ class CoreRootController extends PageCubit<CorePageState> {
   }
 
   Future<void> _shareFile(BuildContext context, String path) async {
-    Rect? sharePositionOrigin;
-    if (context.mounted) {
-      final box = context.findRenderObject() as RenderBox?;
-      if (box != null) {
-        sharePositionOrigin = box.localToGlobal(Offset.zero) & box.size;
-      }
-    }
-    await SharePlus.instance.share(
+    final sharePositionOrigin = ContextShare.positionOrigin(context);
+    await ContextShare.share(
       ShareParams(
         files: [XFile(path)],
         fileNameOverrides: [p.basename(path)],

--- a/lib/pages/home/share/controller.dart
+++ b/lib/pages/home/share/controller.dart
@@ -15,6 +15,7 @@ import 'package:onexray/core/tools/file.dart';
 import 'package:onexray/core/tools/json.dart';
 import 'package:onexray/core/tools/logger.dart';
 import 'package:onexray/pages/mixin/alert.dart';
+import 'package:onexray/pages/mixin/share.dart';
 import 'package:onexray/service/localizations/service.dart';
 import 'package:onexray/l10n/localizations/app_localizations.dart';
 import 'package:onexray/pages/home/share/params.dart';
@@ -305,13 +306,7 @@ class ShareController extends PageCubit<SharePageState> {
   }
 
   Future<void> _shareQrcode(BuildContext context, Uint8List qrcode) async {
-    Rect? sharePositionOrigin;
-    if (context.mounted) {
-      final box = context.findRenderObject() as RenderBox?;
-      if (box != null) {
-        sharePositionOrigin = box.localToGlobal(Offset.zero) & box.size;
-      }
-    }
+    final sharePositionOrigin = ContextShare.positionOrigin(context);
 
     final cacheDir = await FileTool.makeCacheDir();
     final imagePath = p.join(cacheDir, "$_name.png");
@@ -322,15 +317,16 @@ class ShareController extends PageCubit<SharePageState> {
       fileNameOverrides: [_name],
       sharePositionOrigin: sharePositionOrigin,
     );
-    final result = await SharePlus.instance.share(params);
+    final outcome = await ContextShare.share(params);
     await FileTool.deleteDirIfExists(cacheDir);
-    if (context.mounted) {
-      _showActionResult(
-        context,
-        result.status == ShareResultStatus.success,
-        AppLocalizations.of(context)!.sharePageShareQRCode,
-      );
+    if (!context.mounted || outcome == ShareOutcome.unconfirmed) {
+      return;
     }
+    _showActionResult(
+      context,
+      outcome == ShareOutcome.success,
+      AppLocalizations.of(context)!.sharePageShareQRCode,
+    );
   }
 
   void _showActionResult(BuildContext context, bool success, String action) {
@@ -393,27 +389,22 @@ class ShareController extends PageCubit<SharePageState> {
   }
 
   Future<void> _shareUrl(BuildContext context, String url) async {
-    Rect? sharePositionOrigin;
-    if (context.mounted) {
-      final box = context.findRenderObject() as RenderBox?;
-      if (box != null) {
-        sharePositionOrigin = box.localToGlobal(Offset.zero) & box.size;
-      }
-    }
+    final sharePositionOrigin = ContextShare.positionOrigin(context);
     final params = ShareParams(
       text: url,
       subject: _name,
       sharePositionOrigin: sharePositionOrigin,
     );
-    final result = await SharePlus.instance.share(params);
+    final outcome = await ContextShare.share(params);
 
-    if (context.mounted) {
-      _showActionResult(
-        context,
-        result.status == ShareResultStatus.success,
-        AppLocalizations.of(context)!.sharePageShareLink,
-      );
+    if (!context.mounted || outcome == ShareOutcome.unconfirmed) {
+      return;
     }
+    _showActionResult(
+      context,
+      outcome == ShareOutcome.success,
+      AppLocalizations.of(context)!.sharePageShareLink,
+    );
   }
 
   Future<void> copyLinkUrl(BuildContext context) async {
@@ -448,27 +439,22 @@ class ShareController extends PageCubit<SharePageState> {
   }
 
   Future<void> _shareText(BuildContext context, String text) async {
-    Rect? sharePositionOrigin;
-    if (context.mounted) {
-      final box = context.findRenderObject() as RenderBox?;
-      if (box != null) {
-        sharePositionOrigin = box.localToGlobal(Offset.zero) & box.size;
-      }
-    }
+    final sharePositionOrigin = ContextShare.positionOrigin(context);
     final params = ShareParams(
       text: text,
       subject: _name,
       sharePositionOrigin: sharePositionOrigin,
     );
-    final result = await SharePlus.instance.share(params);
+    final outcome = await ContextShare.share(params);
 
-    if (context.mounted) {
-      _showActionResult(
-        context,
-        result.status == ShareResultStatus.success,
-        AppLocalizations.of(context)!.sharePageShareText,
-      );
+    if (!context.mounted || outcome == ShareOutcome.unconfirmed) {
+      return;
     }
+    _showActionResult(
+      context,
+      outcome == ShareOutcome.success,
+      AppLocalizations.of(context)!.sharePageShareText,
+    );
   }
 
   Future<void> copyText(BuildContext context) async {
@@ -495,13 +481,7 @@ class ShareController extends PageCubit<SharePageState> {
   }
 
   Future<void> _shareJsonFile(BuildContext context, String text) async {
-    Rect? sharePositionOrigin;
-    if (context.mounted) {
-      final box = context.findRenderObject() as RenderBox?;
-      if (box != null) {
-        sharePositionOrigin = box.localToGlobal(Offset.zero) & box.size;
-      }
-    }
+    final sharePositionOrigin = ContextShare.positionOrigin(context);
 
     final cacheDir = await FileTool.makeCacheDir();
     final fileName = "${_safeFileName()}.json";
@@ -513,15 +493,16 @@ class ShareController extends PageCubit<SharePageState> {
       fileNameOverrides: [fileName],
       sharePositionOrigin: sharePositionOrigin,
     );
-    final result = await SharePlus.instance.share(params);
+    final outcome = await ContextShare.share(params);
     await FileTool.deleteDirIfExists(cacheDir);
-    if (context.mounted) {
-      _showActionResult(
-        context,
-        result.status == ShareResultStatus.success,
-        AppLocalizations.of(context)!.sharePageShareJsonFile,
-      );
+    if (!context.mounted || outcome == ShareOutcome.unconfirmed) {
+      return;
     }
+    _showActionResult(
+      context,
+      outcome == ShareOutcome.success,
+      AppLocalizations.of(context)!.sharePageShareJsonFile,
+    );
   }
 
   Future<void> saveJsonFile(BuildContext context) async {

--- a/lib/pages/mixin/share.dart
+++ b/lib/pages/mixin/share.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:onexray/core/tools/logger.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// How far the platform share sheet got, as far as the platform can tell.
+enum ShareOutcome {
+  /// The platform confirmed the user completed the share.
+  success,
+
+  /// The user dismissed the sheet, or the platform cannot report an outcome.
+  /// Windows always lands here, even after its share flyout opened, so this
+  /// outcome must never be reported to the user as a failure.
+  unconfirmed,
+
+  /// The platform rejected the share.
+  failed,
+}
+
+/// Shared plumbing for the platform share sheet.
+class ContextShare {
+  /// The anchor rect iPad and macOS need to place the share popover.
+  ///
+  /// Returns null when [context] cannot supply one. A context taken from a
+  /// sliver `itemBuilder` is the common case: it belongs to the sliver element,
+  /// so its render object is a [RenderSliver] instead of a [RenderBox]. Rows
+  /// that want a row-sized anchor have to wrap themselves in a [Builder] and
+  /// pass that context on to their callbacks.
+  static Rect? positionOrigin(BuildContext context) {
+    if (!context.mounted) {
+      return null;
+    }
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      return null;
+    }
+    return renderObject.localToGlobal(Offset.zero) & renderObject.size;
+  }
+
+  /// Opens the platform share sheet and classifies the outcome.
+  ///
+  /// Channel errors are logged and reported as [ShareOutcome.failed] instead of
+  /// escaping as an unhandled asynchronous error. Nothing about [params] is
+  /// logged, because shared text can carry node credentials.
+  static Future<ShareOutcome> share(ShareParams params) async {
+    try {
+      final result = await SharePlus.instance.share(params);
+      return result.status == ShareResultStatus.success
+          ? ShareOutcome.success
+          : ShareOutcome.unconfirmed;
+    } catch (e, stackTrace) {
+      ygLogger("share sheet failed: $e\n$stackTrace");
+      return ShareOutcome.failed;
+    }
+  }
+}

--- a/lib/pages/settings/backup/controller.dart
+++ b/lib/pages/settings/backup/controller.dart
@@ -6,6 +6,7 @@ import 'package:onexray/pages/mixin/page_cubit.dart';
 import 'package:onexray/core/tools/file.dart';
 import 'package:onexray/l10n/localizations/app_localizations.dart';
 import 'package:onexray/pages/mixin/alert.dart';
+import 'package:onexray/pages/mixin/share.dart';
 import 'package:onexray/pages/widget/menu_picker.dart';
 import 'package:onexray/service/share/backup.dart';
 import 'package:path/path.dart' as p;
@@ -122,26 +123,21 @@ class BackupController extends PageCubit<BackupPageState> {
   }
 
   Future<void> _shareFile(BuildContext context, FileInfo file) async {
-    Rect? sharePositionOrigin;
-    if (context.mounted) {
-      final box = context.findRenderObject() as RenderBox?;
-      if (box != null) {
-        sharePositionOrigin = box.localToGlobal(Offset.zero) & box.size;
-      }
-    }
+    final sharePositionOrigin = ContextShare.positionOrigin(context);
     final params = ShareParams(
       files: [XFile(file.path)],
       fileNameOverrides: [file.name],
       sharePositionOrigin: sharePositionOrigin,
     );
-    final result = await SharePlus.instance.share(params);
-    if (context.mounted) {
-      _showActionResult(
-        context,
-        result.status == ShareResultStatus.success,
-        AppLocalizations.of(context)!.menuShare,
-      );
+    final outcome = await ContextShare.share(params);
+    if (!context.mounted || outcome == ShareOutcome.unconfirmed) {
+      return;
     }
+    _showActionResult(
+      context,
+      outcome == ShareOutcome.success,
+      AppLocalizations.of(context)!.menuShare,
+    );
   }
 
   void _showActionResult(BuildContext context, bool success, String action) {

--- a/lib/pages/settings/backup/page.dart
+++ b/lib/pages/settings/backup/page.dart
@@ -82,8 +82,14 @@ class BackupPage extends StatelessWidget {
             groupValue: state.selection,
             onChanged: controller.updateSelection,
             child: ListView.separated(
-              itemBuilder: (ctx, index) =>
-                  _itemRow(ctx, state, controller, index),
+              // The itemBuilder context is the sliver element, so its render
+              // object is a RenderSliver. Builder hands the row callbacks a
+              // context that resolves to the row's RenderBox, which the share
+              // sheet needs as its anchor.
+              itemBuilder: (_, index) => Builder(
+                builder: (rowContext) =>
+                    _itemRow(rowContext, state, controller, index),
+              ),
               itemCount: state.files.length,
               separatorBuilder: (_, _) => const Divider(height: 1),
             ),

--- a/test/pages/mixin/share_test.dart
+++ b/test/pages/mixin/share_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onexray/pages/mixin/share.dart';
+import 'package:share_plus/share_plus.dart';
+
+const _shareChannel = MethodChannel('dev.fluttercommunity.plus/share');
+
+/// The replies share_plus maps to its two non-success statuses.
+const _dismissedReply = '';
+const _unavailableReply = 'dev.fluttercommunity.plus/share/unavailable';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+  final messenger = binding.defaultBinaryMessenger;
+
+  group('positionOrigin', () {
+    testWidgets('reads the rect of the render box below the context', (
+      tester,
+    ) async {
+      late BuildContext boxContext;
+      await tester.pumpWidget(
+        Center(
+          child: Builder(
+            builder: (context) {
+              boxContext = context;
+              return const SizedBox(width: 120, height: 40);
+            },
+          ),
+        ),
+      );
+
+      final origin = ContextShare.positionOrigin(boxContext);
+      expect(origin, tester.getRect(find.byType(SizedBox)));
+      expect(origin?.size, const Size(120, 40));
+    });
+
+    testWidgets('has no anchor for a sliver itemBuilder context', (
+      tester,
+    ) async {
+      late BuildContext sliverContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ListView.builder(
+            itemCount: 1,
+            itemBuilder: (context, index) {
+              sliverContext = context;
+              return const SizedBox(height: 40);
+            },
+          ),
+        ),
+      );
+
+      // The itemBuilder context belongs to the sliver element, so its render
+      // object is a RenderSliver. Reading it as a RenderBox is what used to
+      // abort the share before it reached the platform.
+      final renderObject = sliverContext.findRenderObject();
+      expect(renderObject, isNotNull);
+      expect(renderObject, isNot(isA<RenderBox>()));
+      expect(ContextShare.positionOrigin(sliverContext), isNull);
+    });
+
+    testWidgets('has no anchor once the context is unmounted', (tester) async {
+      late BuildContext boxContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              boxContext = context;
+              return const SizedBox(width: 120, height: 40);
+            },
+          ),
+        ),
+      );
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+      expect(boxContext.mounted, isFalse);
+      expect(ContextShare.positionOrigin(boxContext), isNull);
+    });
+  });
+
+  group('share', () {
+    late List<MethodCall> calls;
+    late Object? reply;
+
+    setUp(() {
+      calls = <MethodCall>[];
+      reply = _unavailableReply;
+      messenger.setMockMethodCallHandler(_shareChannel, (call) async {
+        calls.add(call);
+        final answer = reply;
+        if (answer is PlatformException) {
+          throw answer;
+        }
+        return answer as String?;
+      });
+    });
+
+    tearDown(() {
+      messenger.setMockMethodCallHandler(_shareChannel, null);
+    });
+
+    test('reports success when the platform names the chosen target', () async {
+      reply = 'net.yuandev.onexray.receiver';
+
+      final outcome = await ContextShare.share(ShareParams(text: 'onexray'));
+
+      expect(outcome, ShareOutcome.success);
+      expect(calls.single.method, 'share');
+    });
+
+    test('stays unconfirmed when the user dismissed the sheet', () async {
+      reply = _dismissedReply;
+
+      expect(
+        await ContextShare.share(ShareParams(text: 'onexray')),
+        ShareOutcome.unconfirmed,
+      );
+    });
+
+    test('stays unconfirmed when the platform cannot answer', () async {
+      // Windows always answers this, even after its share flyout opened, so it
+      // must never be reported to the user as a failure.
+      reply = _unavailableReply;
+
+      expect(
+        await ContextShare.share(ShareParams(text: 'onexray')),
+        ShareOutcome.unconfirmed,
+      );
+    });
+
+    test('reports a failure when the channel rejects the share', () async {
+      reply = PlatformException(code: 'Share failed');
+
+      expect(
+        await ContextShare.share(ShareParams(text: 'onexray')),
+        ShareOutcome.failed,
+      );
+      expect(calls, hasLength(1));
+    });
+  });
+}

--- a/test/pages/settings/backup/page_test.dart
+++ b/test/pages/settings/backup/page_test.dart
@@ -1,0 +1,245 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onexray/l10n/localizations/app_localizations.dart';
+import 'package:onexray/pages/settings/backup/controller.dart';
+import 'package:onexray/pages/settings/backup/page.dart';
+import 'package:onexray/pages/theme/theme.dart';
+import 'package:onexray/pages/widget/data_list.dart';
+import 'package:onexray/pages/widget/menu_picker.dart';
+import 'package:onexray/service/event_bus/service.dart';
+import 'package:path/path.dart' as p;
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+const _pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+const _shareChannel = MethodChannel('dev.fluttercommunity.plus/share');
+
+/// The reply share_plus maps to a share sheet the user dismissed.
+const _dismissedReply = '';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+  final messenger = binding.defaultBinaryMessenger;
+
+  late AppEventBus eventBus;
+  late Directory supportDir;
+  late File backupFile;
+  late List<MethodCall> shareCalls;
+  late Object? shareReply;
+
+  setUp(() async {
+    // Menu titles are read through AppEventBus, and BackupService resolves the
+    // backup directory through path_provider.
+    eventBus = AppEventBus();
+    supportDir = await Directory.systemTemp.createTemp('onexray_backup_test');
+    backupFile = File(
+      p.join(supportDir.path, 'backup', 'OneXray-2026-09-02.zip'),
+    );
+    await backupFile.parent.create(recursive: true);
+    await backupFile.writeAsBytes(const [0x50, 0x4b, 0x05, 0x06]);
+
+    shareCalls = <MethodCall>[];
+    shareReply = 'net.yuandev.onexray.receiver';
+    messenger.setMockMethodCallHandler(
+      _pathProviderChannel,
+      (call) async => call.method == 'getApplicationSupportDirectory'
+          ? supportDir.path
+          : null,
+    );
+    messenger.setMockMethodCallHandler(_shareChannel, (call) async {
+      shareCalls.add(call);
+      final reply = shareReply;
+      if (reply is PlatformException) {
+        throw reply;
+      }
+      return reply as String?;
+    });
+  });
+
+  tearDown(() async {
+    messenger.setMockMethodCallHandler(_pathProviderChannel, null);
+    messenger.setMockMethodCallHandler(_shareChannel, null);
+    await eventBus.close();
+    if (supportDir.existsSync()) {
+      await supportDir.delete(recursive: true);
+    }
+  });
+
+  testWidgets('sharing a backup row anchors the share sheet on that row', (
+    tester,
+  ) async {
+    await _pumpBackupPage(tester);
+    expect(find.text(p.basename(backupFile.path)), findsOneWidget);
+
+    await _selectRowMenu(tester, IconMenuId.share);
+
+    expect(tester.takeException(), isNull);
+    expect(shareCalls, hasLength(1));
+    final arguments = _shareArguments(shareCalls.single);
+    expect(arguments['paths'], [backupFile.path]);
+    // The anchor has to be the row's own box. Rows are built by a sliver
+    // itemBuilder, whose context resolves to a RenderSliver, so the row has to
+    // hand its callbacks a context of its own.
+    final rowRect = tester.getRect(find.byType(DataListRow));
+    expect(arguments['originWidth'], rowRect.width);
+    expect(arguments['originHeight'], rowRect.height);
+    expect(find.text('Share successfully'), findsOneWidget);
+
+    await _drainToast(tester);
+  });
+
+  testWidgets('sharing survives a row callback bound to the sliver context', (
+    tester,
+  ) async {
+    final controller = BackupController();
+    addTearDown(controller.close);
+
+    await tester.pumpWidget(
+      _app(
+        _SliverContextRowHost(
+          controller: controller,
+          file: _fileInfo(backupFile),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('trigger'));
+    await tester.pumpAndSettle();
+
+    // The sliver context cannot supply an anchor, but it must not abort the
+    // share either.
+    expect(tester.takeException(), isNull);
+    expect(shareCalls, hasLength(1));
+    final arguments = _shareArguments(shareCalls.single);
+    expect(arguments['paths'], [backupFile.path]);
+    expect(arguments.containsKey('originWidth'), isFalse);
+    expect(find.text('Share successfully'), findsOneWidget);
+
+    await _drainToast(tester);
+  });
+
+  testWidgets('a dismissed share sheet reports nothing', (tester) async {
+    shareReply = _dismissedReply;
+
+    await _pumpBackupPage(tester);
+    await _selectRowMenu(tester, IconMenuId.share);
+
+    expect(tester.takeException(), isNull);
+    expect(shareCalls, hasLength(1));
+    expect(find.text('Share successfully'), findsNothing);
+    expect(find.text('Share failed'), findsNothing);
+  });
+
+  testWidgets('a rejected share reports a failure', (tester) async {
+    shareReply = PlatformException(code: 'Share failed');
+
+    await _pumpBackupPage(tester);
+    await _selectRowMenu(tester, IconMenuId.share);
+
+    expect(tester.takeException(), isNull);
+    expect(shareCalls, hasLength(1));
+    expect(find.text('Share failed'), findsOneWidget);
+
+    await _drainToast(tester);
+  });
+}
+
+/// Pumps [BackupPage] and waits for the disk read its controller starts.
+///
+/// The row list comes from real file I/O. It only lands while
+/// [WidgetTester.runAsync] gives the real event loop a turn, and the
+/// continuations it schedules only run on the next pump, so the two have to
+/// alternate until the controller reports the files it found.
+Future<void> _pumpBackupPage(WidgetTester tester) async {
+  // The action bar does not fit the default 800x600 test surface.
+  await tester.binding.setSurfaceSize(const Size(390, 844));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(_app(const BackupPage()));
+  final controller = BlocProvider.of<BackupController>(
+    tester.element(find.byType(BlocBuilder<BackupController, BackupPageState>)),
+  );
+  for (var turn = 0; turn < 50 && controller.state.files.isEmpty; turn++) {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 5)),
+    );
+    await tester.pump();
+  }
+  expect(controller.state.files, isNotEmpty);
+  await tester.pumpAndSettle();
+}
+
+/// Picks [menuId] the way the row's overflow menu does.
+///
+/// The menu entries are platform gated: `IconMenuId.share` is hidden on Linux,
+/// so the entry itself cannot be tapped on every host. Calling the callback the
+/// page captured still covers the wiring under test, which is the context the
+/// row hands to the controller.
+Future<void> _selectRowMenu(WidgetTester tester, IconMenuId menuId) async {
+  final menuButton = tester.widget<AppMenuButton<IconMenuId>>(
+    find.byType(AppMenuButton<IconMenuId>),
+  );
+  menuButton.onSelected(menuId);
+  await tester.pumpAndSettle();
+}
+
+/// Lets the toast time out so the test ends without pending timers.
+Future<void> _drainToast(WidgetTester tester) async {
+  await tester.pump(const Duration(seconds: 5));
+  await tester.pumpAndSettle();
+}
+
+/// Hosts a row whose callbacks are bound to the raw `itemBuilder` context, the
+/// wiring that used to abort the share.
+class _SliverContextRowHost extends StatelessWidget {
+  const _SliverContextRowHost({required this.controller, required this.file});
+
+  final BackupController controller;
+  final FileInfo file;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ListView.separated(
+        itemBuilder: (sliverContext, index) => SizedBox(
+          height: 56,
+          child: TextButton(
+            onPressed: () =>
+                controller.moreAction(sliverContext, file, IconMenuId.share),
+            child: const Text('trigger'),
+          ),
+        ),
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemCount: 1,
+      ),
+    );
+  }
+}
+
+/// Mirrors the app shell from `lib/pages/main/router.dart`, which owns the
+/// ShadTheme and the toaster the controller reports through.
+Widget _app(Widget child) {
+  return MaterialApp(
+    theme: AppTheme.light,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    builder: (context, appChild) => ShadTheme(
+      data: AppTheme.shad(Theme.of(context).brightness),
+      child: ShadToaster(child: appChild ?? const SizedBox.shrink()),
+    ),
+    home: child,
+  );
+}
+
+FileInfo _fileInfo(File file) =>
+    FileInfo(p.basename(file.path), file.path)
+      ..timestamp = file.lastModifiedSync();
+
+Map<String, Object?> _shareArguments(MethodCall call) {
+  expect(call.method, 'share');
+  return (call.arguments as Map).cast<String, Object?>();
+}


### PR DESCRIPTION
`On Settings` → `Backup & Restore`, picking `Share` from a row's menu does nothing.

<img width="1128" height="892" alt="backup share" src="https://github.com/user-attachments/assets/8d8adab5-0f6c-4b07-bf76-692f6374085f" />

`ListView.separated` passes its `itemBuilder` the sliver element's context, so `findRenderObject()` there returns a `RenderSliver`. The old `as RenderBox?` cast threw before the share sheet was ever opened, and the menu callback drops the returned future, so the error never showed up anywhere.

Checking the other five share call sites turned up a second problem: the Windows plugin always answers `unavailable`, even when its flyout opened fine, so the old `status != success` check reported "Share failed" on every Windows share.

<img width="1434" height="892" alt="share failed" src="https://github.com/user-attachments/assets/a2d144ee-6440-4598-b2f7-d16bb4e46083" />

Two commits:

1. `ContextShare` (`lib/pages/mixin/share.dart`) resolves the popover anchor only when the context really carries a laid-out `RenderBox`, opens the sheet, and reports `success` / `unconfirmed` / `failed`. Channel errors are logged instead of being left as unhandled async errors. `ShareParams` is deliberately not logged, since shared text can contain node credentials. Backup rows are wrapped in a `Builder` so the callback gets a context that resolves to the row's own box, which is the anchor the iPad and macOS popover was meant to use in the first place.

2. The remaining five call sites move onto the helper, and a failure is only reported when the platform actually rejected the share. A dismissed sheet, or a platform that cannot tell, stays quiet.