### PR TITLE
Add configurable local and tunnel DNS settings

### DIFF
--- a/docs/app-navigation.md
+++ b/docs/app-navigation.md
@@ -78,10 +78,9 @@ Raw 新增最多三份；已有超额旧数据仍完整显示、可编辑和选�
 
 高级是第三个根级入口，分为“VPN 隧道”和“Xray”两个 Tab。
 
-- VPN Tunnel: read-only TUN addresses, editable IPv4/IPv6 DNS and server name,
-  and a separate IPv6 switch. DNS inputs remain on this page; the server-name
-  hint explains its Apple DoT-only use. Platform configuration uses detail pages.
-  The outbound interface appears only on Windows/Linux and requires selection.
+- VPN 隧道：只读 TUN 地址、可编辑的 IPv4/IPv6 DNS 和服务器域名，以及独立 IPv6 开关。
+  DNS 输入保留在本页；域名提示说明其仅用于 Apple DoT。平台配置使用详情页。
+  出口网卡只在 Windows/Linux 显示，必须明确选择。
 - Apple：始终开启、按需 Wi-Fi 连接/断开规则及平台对应的蜂窝/Ethernet；接管全部流量
   打开后显示四项系统排除设置。关闭时可编辑绕过 VPN 的 IPv4/IPv6 网段，默认列表为空；
   重新打开后隐藏编辑控件、提示列表不生效，并保留已保存的内容。修改有效网段时复用

--- a/docs/app-navigation.md
+++ b/docs/app-navigation.md
@@ -78,8 +78,10 @@ Raw 新增最多三份；已有超额旧数据仍完整显示、可编辑和选�
 
 高级是第三个根级入口，分为“VPN 隧道”和“Xray”两个 Tab。
 
-- VPN 隧道：只读 TUN 地址与双栈 Google DNS/域名、独立 IPv6 开关；平台配置使用详情页。
-  出口网卡只在 Windows/Linux 显示，必须明确选择。
+- VPN Tunnel: read-only TUN addresses, editable IPv4/IPv6 DNS and server name,
+  and a separate IPv6 switch. DNS inputs remain on this page; the server-name
+  hint explains its Apple DoT-only use. Platform configuration uses detail pages.
+  The outbound interface appears only on Windows/Linux and requires selection.
 - Apple：始终开启、按需 Wi-Fi 连接/断开规则及平台对应的蜂窝/Ethernet；接管全部流量
   打开后显示四项系统排除设置。关闭时可编辑绕过 VPN 的 IPv4/IPv6 网段，默认列表为空；
   重新打开后隐藏编辑控件、提示列表不生效，并保留已保存的内容。修改有效网段时复用

--- a/docs/xray-configuration.md
+++ b/docs/xray-configuration.md
@@ -77,10 +77,35 @@ Windows 服务直连开关在所有平台显示；开启后使用 Microsoft、Bi
 
 “所有流量经过 VPN”只生成一个走 proxy 的 `8.8.8.8` DNS server，不生成直连 DNS server
 及其路由规则；`dnsOut` 对非 A/AAAA 查询的转发也走当前代理节点。
-智能路由和自定义路由保留两个 `8.8.8.8` server，以独立 tag 分别走 proxy/direct。
+Smart and Custom routing keep two independently tagged DNS servers. Proxy DNS
+remains `8.8.8.8`; direct DNS defaults to that address and is independently
+editable in each routing configuration. Smart retains the saved address when
+its direct-DNS switch is off, but uses the previous default with no direct domain
+matches until the switch is enabled again. Direct-DNS address syntax is validated
+by libXray, not a separate App protocol or reachability check.
 direct server 的 domains 从当前 direct 规则提取，且不作为通用 fallback；DNS 阶段不
 宣称已判断 IP、端口或网络条件。普通模式只给每个 server 设置查询策略，不生成根级 `hosts` 或
 `queryStrategy`。直连地区依据安装的官方 Geosite/GeoIP 分类和随包地区映射生成。
+
+## Tunnel DNS
+
+The VPN Tunnel page edits IPv4 DNS, IPv6 DNS, and the DNS server name in the
+existing platform-policy JSON. Missing fields retain the previous Google
+defaults. These global settings are independent of per-route direct DNS and
+do not change Raw JSON's own DNS addresses. No database columns or schema
+upgrade are needed.
+
+The existing native TUN request carries the configured addresses to Apple and
+Android; Linux and Windows EXE also use them in the generated Xray TUN inbound.
+Windows MSIX uses them in its network settings and exclusion checks, preserving
+its existing IPv6 handling. Native DNS addresses must be IP literals of the
+corresponding family. Inactive IPv6 values are retained without applying them.
+
+The server name is used only for Apple DNS over TLS, not as a search domain.
+With DoT enabled, the addresses and name must describe the same service and its
+TLS certificate. Changes to effective DNS settings use the existing save and
+confirmed-reconnect workflow; inactive server-name and IPv6 edits do not cause
+a reconnect. Restoring defaults changes only the draft until saved.
 
 ## IPv6 策略
 
@@ -103,6 +128,14 @@ IPv6 而拒绝 IPv6 节点或 DNS 地址。Raw 中用户自带的路由、hosts�
 保持不变；关闭开关不代表 Xray 的所有 IPv6 流量都被禁止。
 
 ## 自定义路由
+
+Custom routing stores and shares its direct DNS address as
+`dns.servers: [{"tag":"app-dns-direct","address":"8.8.8.8"}]`.
+The fixed tag identifies the server, not its array position. Only this single
+tagged server's `address` is editable; domains, fallback and query strategy are
+generated during validation and runtime compilation, not stored or exported.
+Existing profiles without DNS use the previous default. Unsupported DNS fields,
+untagged servers and duplicate servers are rejected rather than silently lost.
 
 普通 Custom 的持久化链路固定为 `RoutingProfile` 表 ↔ `XrayJson` ↔
 `RoutingProfileState`：数据库适配层负责 Base64 解码、模型解析和规范化重编码，业务与 UI

--- a/docs/xray-configuration.md
+++ b/docs/xray-configuration.md
@@ -77,35 +77,27 @@ Windows 服务直连开关在所有平台显示；开启后使用 Microsoft、Bi
 
 “所有流量经过 VPN”只生成一个走 proxy 的 `8.8.8.8` DNS server，不生成直连 DNS server
 及其路由规则；`dnsOut` 对非 A/AAAA 查询的转发也走当前代理节点。
-Smart and Custom routing keep two independently tagged DNS servers. Proxy DNS
-remains `8.8.8.8`; direct DNS defaults to that address and is independently
-editable in each routing configuration. Smart retains the saved address when
-its direct-DNS switch is off, but uses the previous default with no direct domain
-matches until the switch is enabled again. Direct-DNS address syntax is validated
-by libXray, not a separate App protocol or reachability check.
+智能路由和自定义路由保留两个使用独立 tag 的 DNS server。代理 DNS 固定为 `8.8.8.8`；
+直连 DNS 默认使用该地址，可在各份路由配置中独立修改。智能路由关闭直连 DNS 开关后，
+保留已保存的地址，但运行时使用原默认地址且不匹配直连域名，直到重新开启开关。
+直连 DNS 地址的语法由 libXray 校验，App 不另行检查协议或连通性。
 direct server 的 domains 从当前 direct 规则提取，且不作为通用 fallback；DNS 阶段不
 宣称已判断 IP、端口或网络条件。普通模式只给每个 server 设置查询策略，不生成根级 `hosts` 或
 `queryStrategy`。直连地区依据安装的官方 Geosite/GeoIP 分类和随包地区映射生成。
 
-## Tunnel DNS
+## 隧道 DNS
 
-The VPN Tunnel page edits IPv4 DNS, IPv6 DNS, and the DNS server name in the
-existing platform-policy JSON. Missing fields retain the previous Google
-defaults. These global settings are independent of per-route direct DNS and
-do not change Raw JSON's own DNS addresses. No database columns or schema
-upgrade are needed.
+VPN 隧道页可编辑 IPv4 DNS、IPv6 DNS 和 DNS 服务器域名，保存在现有平台策略 JSON 中。
+缺失字段沿用原 Google 默认值。这些全局设置独立于各份路由的直连 DNS，不修改 Raw JSON
+自身的 DNS 地址，无需新增数据库列或升级 schema。
 
-The existing native TUN request carries the configured addresses to Apple and
-Android; Linux and Windows EXE also use them in the generated Xray TUN inbound.
-Windows MSIX uses them in its network settings and exclusion checks, preserving
-its existing IPv6 handling. Native DNS addresses must be IP literals of the
-corresponding family. Inactive IPv6 values are retained without applying them.
+现有原生 TUN 请求将配置的地址传给 Apple 和 Android；Linux 和 Windows EXE 生成的 Xray
+TUN 入站也使用这些地址。Windows MSIX 将其用于网络设置和排除规则校验，保持现有 IPv6
+处理方式。原生 DNS 地址必须是对应地址族的 IP 字面量；未生效的 IPv6 值仅保留，不应用。
 
-The server name is used only for Apple DNS over TLS, not as a search domain.
-With DoT enabled, the addresses and name must describe the same service and its
-TLS certificate. Changes to effective DNS settings use the existing save and
-confirmed-reconnect workflow; inactive server-name and IPv6 edits do not cause
-a reconnect. Restoring defaults changes only the draft until saved.
+服务器域名仅用于 Apple DNS over TLS，不作为搜索域。开启 DoT 时，地址与域名必须属于
+同一服务，并与其 TLS 证书匹配。有效 DNS 设置的修改复用现有保存及确认重连流程；修改
+未生效的服务器域名或 IPv6 设置不触发重连。恢复默认只修改草稿，保存后才生效。
 
 ## IPv6 策略
 
@@ -129,13 +121,11 @@ IPv6 而拒绝 IPv6 节点或 DNS 地址。Raw 中用户自带的路由、hosts�
 
 ## 自定义路由
 
-Custom routing stores and shares its direct DNS address as
-`dns.servers: [{"tag":"app-dns-direct","address":"8.8.8.8"}]`.
-The fixed tag identifies the server, not its array position. Only this single
-tagged server's `address` is editable; domains, fallback and query strategy are
-generated during validation and runtime compilation, not stored or exported.
-Existing profiles without DNS use the previous default. Unsupported DNS fields,
-untagged servers and duplicate servers are rejected rather than silently lost.
+自定义路由通过 `dns.servers: [{"tag":"app-dns-direct","address":"8.8.8.8"}]`
+存储和分享直连 DNS 地址。使用固定 tag 标记服务器，不依赖数组位置；仅允许编辑这一条
+带标签服务器的 `address`。域名匹配、回退和查询策略在校验及运行编译时生成，不存储或
+导出。已有配置未包含 DNS 时沿用原默认值；不支持的 DNS 字段、无标签服务器和重复
+服务器直接拒绝，不静默丢弃。
 
 普通 Custom 的持久化链路固定为 `RoutingProfile` 表 ↔ `XrayJson` ↔
 `RoutingProfileState`：数据库适配层负责 Base64 解码、模型解析和规范化重编码，业务与 UI

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,6 @@
 {
+  "routingLocalDnsAddress": "Local DNS address",
+  "tunnelDnsServerNameHint": "Used only for DNS over TLS on Apple platforms. The DNS addresses and server name must belong to the same service and match its TLS certificate.",
   "menuShortcutChooseConfiguration": "Switch configuration",
   "menuShortcutUpdateSubscriptions": "Update subscriptions",
   "menuBarReconnect": "Reconnect",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -1,4 +1,6 @@
 {
+  "routingLocalDnsAddress": "آدرس DNS محلی",
+  "tunnelDnsServerNameHint": "فقط برای DNS over TLS در پلتفرم‌های Apple استفاده می‌شود. آدرس‌های DNS و نام سرور باید متعلق به یک سرویس باشند و با گواهی TLS آن مطابقت داشته باشند.",
   "menuShortcutChooseConfiguration": "تغییر پیکربندی",
   "menuShortcutUpdateSubscriptions": "به‌روزرسانی اشتراک‌ها",
   "menuBarReconnect": "اتصال مجدد",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,4 +1,6 @@
 {
+  "routingLocalDnsAddress": "Адрес локального DNS",
+  "tunnelDnsServerNameHint": "Используется только для DNS over TLS на платформах Apple. Адреса DNS и имя сервера должны принадлежать одной службе и соответствовать её TLS-сертификату.",
   "menuShortcutChooseConfiguration": "Сменить конфигурацию",
   "menuShortcutUpdateSubscriptions": "Обновить подписки",
   "menuBarReconnect": "Переподключиться",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,4 +1,6 @@
 {
+  "routingLocalDnsAddress": "本地 DNS 地址",
+  "tunnelDnsServerNameHint": "仅用于 Apple 平台的 DNS over TLS。DNS 地址与域名必须属于同一服务，并与其 TLS 证书匹配。",
   "menuShortcutChooseConfiguration": "切换配置",
   "menuShortcutUpdateSubscriptions": "更新订阅",
   "menuBarReconnect": "重新连接",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1,4 +1,6 @@
 {
+  "routingLocalDnsAddress": "本機 DNS 位址",
+  "tunnelDnsServerNameHint": "僅用於 Apple 平台的 DNS over TLS。DNS 位址與網域名稱必須屬於同一服務，並與其 TLS 憑證相符。",
   "menuShortcutChooseConfiguration": "切換設定",
   "menuShortcutUpdateSubscriptions": "更新訂閱",
   "menuBarReconnect": "重新連線",

--- a/lib/pages/advanced/tunnel/controller.dart
+++ b/lib/pages/advanced/tunnel/controller.dart
@@ -231,13 +231,11 @@ class PolicyEditorController extends PageCubit<PolicyEditorPageState> {
     } on FormatException catch (error) {
       emit(
         state.copyWith(
-          error: supportsWindowsSystemVpn
-              ? l.prototypeBypassNetworkInputHint
-              : connectionFailureMessage(
-                  l,
-                  error: error,
-                  operation: l.buttonSaveFailed,
-                ),
+          error: connectionFailureMessage(
+            l,
+            error: error,
+            operation: l.buttonSaveFailed,
+          ),
         ),
       );
       return false;

--- a/lib/pages/advanced/tunnel/page.dart
+++ b/lib/pages/advanced/tunnel/page.dart
@@ -5,6 +5,7 @@ import 'package:onexray/l10n/localizations/app_localizations.dart';
 import 'package:onexray/pages/advanced/tunnel/controller.dart';
 import 'package:onexray/pages/advanced/tunnel/widgets.dart';
 import 'package:onexray/pages/shared/alert.dart';
+import 'package:onexray/pages/shared/widgets/dns_text_field.dart';
 import 'package:onexray/pages/theme/color.dart';
 import 'package:onexray/pages/theme/font.dart';
 import 'package:onexray/pages/theme/layout.dart';
@@ -105,17 +106,38 @@ class VpnTunnelPane extends StatelessWidget {
                     icon: LucideIcons.globe2,
                     title: l.prototypeTunnelDns,
                     children: [
-                      PolicyValueRow(
-                        title: l.prototypeIpv4Dns,
-                        value: PlatformPolicy.dnsIpv4Address,
-                      ),
-                      PolicyValueRow(
-                        title: l.prototypeIpv6Dns,
-                        value: PlatformPolicy.dnsIpv6Address,
-                      ),
-                      PolicyValueRow(
-                        title: l.prototypeDomain,
-                        value: PlatformPolicy.dnsServerName,
+                      Padding(
+                        padding: const EdgeInsets.all(14),
+                        child: Column(
+                          spacing: 18,
+                          children: [
+                            DnsTextField(
+                              label: l.prototypeIpv4Dns,
+                              value:
+                                  controller.value['dnsIpv4Address'] as String,
+                              enabled: !controller.blocked,
+                              onChanged: (value) =>
+                                  controller.update('dnsIpv4Address', value),
+                            ),
+                            DnsTextField(
+                              label: l.prototypeIpv6Dns,
+                              value:
+                                  controller.value['dnsIpv6Address'] as String,
+                              enabled: !controller.blocked,
+                              onChanged: (value) =>
+                                  controller.update('dnsIpv6Address', value),
+                            ),
+                            DnsTextField(
+                              label: l.prototypeDomain,
+                              value:
+                                  controller.value['dnsServerName'] as String,
+                              enabled: !controller.blocked,
+                              hint: l.tunnelDnsServerNameHint,
+                              onChanged: (value) =>
+                                  controller.update('dnsServerName', value),
+                            ),
+                          ],
+                        ),
                       ),
                     ],
                   ),

--- a/lib/pages/connect/routing/custom/controller.dart
+++ b/lib/pages/connect/routing/custom/controller.dart
@@ -15,6 +15,7 @@ import 'package:onexray/service/connect/routing/custom/editor.dart';
 import 'package:onexray/service/shared/failure.dart';
 import 'package:onexray/service/connect/routing/custom/document.dart';
 import 'package:onexray/service/connect/routing/custom/state.dart';
+import 'package:onexray/service/connect/routing/dns.dart';
 import 'package:onexray/service/shared/share/configuration_transfer.dart';
 
 typedef OpenCustomRule = Future<RoutingRuleState?> Function(
@@ -33,6 +34,7 @@ class CustomRoutingEditorState {
   final List<Object> ruleKeys;
   final Object? selectedRuleKey;
   final int entryCount;
+  final String directDnsAddress;
   final bool processing;
   final bool transferBusy;
   final bool saving;
@@ -49,6 +51,7 @@ class CustomRoutingEditorState {
     Iterable<Object> ruleKeys = const [],
     this.selectedRuleKey,
     this.entryCount = 1,
+    this.directDnsAddress = RoutingDns.defaultAddress,
     this.processing = true,
     this.transferBusy = false,
     this.saving = false,
@@ -73,6 +76,7 @@ class CustomRoutingEditorState {
     Iterable<Object>? ruleKeys,
     Object? selectedRuleKey = _unchangedCustomRoutingValue,
     int? entryCount,
+    String? directDnsAddress,
     bool? processing,
     bool? transferBusy,
     bool? saving,
@@ -92,6 +96,7 @@ class CustomRoutingEditorState {
         ? this.selectedRuleKey
         : selectedRuleKey,
     entryCount: entryCount ?? this.entryCount,
+    directDnsAddress: directDnsAddress ?? this.directDnsAddress,
     processing: processing ?? this.processing,
     transferBusy: transferBusy ?? this.transferBusy,
     saving: saving ?? this.saving,
@@ -202,6 +207,7 @@ class CustomRoutingEditorController
           ruleKeys: keys,
           selectedRuleKey: selected,
           entryCount: value.entryCount,
+          directDnsAddress: value.directDnsAddress,
           processing: false,
           transferBusy: transfer.state.busy,
           inlineEditing: state.inlineEditing,
@@ -240,6 +246,7 @@ class CustomRoutingEditorController
     id: profileId,
     name: state.name.trim(),
     entryCount: state.entryCount,
+    directDnsAddress: state.directDnsAddress.trim(),
     rules: state.rules,
   );
 
@@ -262,6 +269,7 @@ class CustomRoutingEditorController
       state.copyWith(
         name: nextName,
         entryCount: value.entryCount,
+        directDnsAddress: value.directDnsAddress,
         rules: value.rules,
         ruleKeys: keys,
         selectedRuleKey: selected,
@@ -341,6 +349,10 @@ class CustomRoutingEditorController
 
   void setEntryCount(int value) {
     emit(state.copyWith(entryCount: value));
+  }
+
+  void setDirectDnsAddress(String value) {
+    emit(state.copyWith(directDnsAddress: value, error: null));
   }
 
   Future<void> editRule(

--- a/lib/pages/connect/routing/custom/page.dart
+++ b/lib/pages/connect/routing/custom/page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:onexray/pages/shared/widgets/button_progress.dart';
+import 'package:onexray/pages/shared/widgets/dns_text_field.dart';
 import 'package:onexray/l10n/localizations/app_localizations.dart';
 import 'package:onexray/pages/connect/routing/custom/controller.dart';
 import 'package:onexray/pages/connect/routing/custom/rule_page.dart';
@@ -228,7 +229,32 @@ class _CustomRoutingEditorPageState extends State<CustomRoutingEditorPage> {
                                             12,
                                           ),
                                           child: RoutingCard(
-                                            child: _dns(context, mobile),
+                                            child: Column(
+                                              crossAxisAlignment:
+                                                  CrossAxisAlignment.stretch,
+                                              children: [
+                                                _dns(context, mobile),
+                                                Padding(
+                                                  padding:
+                                                      const EdgeInsets.fromLTRB(
+                                                        13,
+                                                        8,
+                                                        13,
+                                                        13,
+                                                      ),
+                                                  child: DnsTextField(
+                                                    label: l
+                                                        .routingLocalDnsAddress,
+                                                    value:
+                                                        state.directDnsAddress,
+                                                    enabled:
+                                                        !state.editingBlocked,
+                                                    onChanged: controller
+                                                        .setDirectDnsAddress,
+                                                  ),
+                                                ),
+                                              ],
+                                            ),
                                           ),
                                         ),
                                       ],

--- a/lib/pages/connect/routing/smart/page.dart
+++ b/lib/pages/connect/routing/smart/page.dart
@@ -10,6 +10,7 @@ import 'package:onexray/pages/theme/font.dart';
 import 'package:onexray/pages/theme/layout.dart';
 import 'package:onexray/pages/shared/widgets/page_action_bar.dart';
 import 'package:onexray/pages/shared/widgets/button_progress.dart';
+import 'package:onexray/pages/shared/widgets/dns_text_field.dart';
 import 'package:onexray/pages/shared/widgets/settings_page.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -181,6 +182,14 @@ class _SmartRoutingEditorPageState extends State<SmartRoutingEditorPage> {
             'directDns',
             smart.directDns,
             state,
+            below: smart.directDns
+                ? DnsTextField(
+                    label: l.routingLocalDnsAddress,
+                    value: smart.directDnsAddress,
+                    onChanged: (value) =>
+                        controller.update('directDnsAddress', value),
+                  )
+                : null,
           ),
           _switch(
             l.prototypeBlockAdDomains,
@@ -225,12 +234,14 @@ class _SmartRoutingEditorPageState extends State<SmartRoutingEditorPage> {
     IconData icon,
     String key,
     bool value,
-    SmartRoutingEditorState state,
-  ) => RoutingSettingRow(
+    SmartRoutingEditorState state, {
+    Widget? below,
+  }) => RoutingSettingRow(
     icon: icon,
     title: title,
     description: description,
     enabled: state.original != null,
+    below: below,
     trailing: Semantics(
       label: title,
       child: ShadSwitch(

--- a/lib/pages/shared/widgets/dns_text_field.dart
+++ b/lib/pages/shared/widgets/dns_text_field.dart
@@ -1,0 +1,61 @@
+import 'package:material_ui/material_ui.dart';
+import 'package:onexray/pages/theme/font.dart';
+
+/// Keeps editing resources local while the owning page Cubit owns the value.
+class DnsTextField extends StatefulWidget {
+  final String label;
+  final String value;
+  final ValueChanged<String> onChanged;
+  final bool enabled;
+  final String? hint;
+
+  const DnsTextField({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    this.enabled = true,
+    this.hint,
+  });
+
+  @override
+  State<DnsTextField> createState() => _DnsTextFieldState();
+}
+
+class _DnsTextFieldState extends State<DnsTextField> {
+  late final controller = TextEditingController(text: widget.value);
+
+  @override
+  void didUpdateWidget(covariant DnsTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (controller.text != widget.value) controller.text = widget.value;
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    spacing: 8,
+    children: [
+      TextField(
+        controller: controller,
+        onChanged: widget.onChanged,
+        enabled: widget.enabled,
+        textDirection: TextDirection.ltr,
+        textAlign: TextAlign.left,
+        keyboardType: TextInputType.url,
+        autocorrect: false,
+        enableSuggestions: false,
+        style: AppTypography.settingsInput,
+        decoration: InputDecoration(labelText: widget.label),
+      ),
+      if (widget.hint != null)
+        Text(widget.hint!, style: Theme.of(context).textTheme.bodySmall),
+    ],
+  );
+}

--- a/lib/service/advanced/platform_policy.dart
+++ b/lib/service/advanced/platform_policy.dart
@@ -25,6 +25,9 @@ final class PlatformPolicy {
 
   factory PlatformPolicy.fromJson(Map<String, dynamic> value) {
     final policy = _readPolicyObject(_defaults, value);
+    for (final key in ['dnsIpv4Address', 'dnsIpv6Address', 'dnsServerName']) {
+      policy[key] = (policy[key] as String).trim();
+    }
     final android = policy['android'] as Map<String, dynamic>;
     if (!{'all', 'included', 'excluded'}.contains(android['appScope'])) {
       throw const FormatException('Invalid Android app scope');
@@ -74,12 +77,40 @@ final class PlatformPolicy {
 
   static const tunIpv4Address = '198.18.0.1';
   static const tunIpv6Address = 'fc00::1';
-  static const dnsIpv4Address = '8.8.8.8';
-  static const dnsIpv6Address = '2001:4860:4860::8888';
-  static const dnsServerName = 'dns.google';
+  String get dnsIpv4Address => toJson()['dnsIpv4Address'] as String;
+  String get dnsIpv6Address => toJson()['dnsIpv6Address'] as String;
+  String get dnsServerName => toJson()['dnsServerName'] as String;
+
+  /// Native DNS setters require IP literals; Xray DNS syntax is independent.
+  void validateDns(ConnectionPlatform platform, {WindowsMode? windowsMode}) {
+    void checkAddress(String value, InternetAddressType family, String label) {
+      final address = RegExp(r'[\[\]%\s]').hasMatch(value)
+          ? null
+          : InternetAddress.tryParse(value);
+      if (address == null || address.type != family) {
+        throw FormatException(
+          '$label must be an ${family.name} address: $value',
+        );
+      }
+    }
+
+    checkAddress(dnsIpv4Address, InternetAddressType.IPv4, 'Tunnel DNS IPv4');
+    if (ipv6Enabled ||
+        (platform == ConnectionPlatform.windows &&
+            (windowsMode ?? windowsBuildMode) == WindowsMode.msix)) {
+      checkAddress(dnsIpv6Address, InternetAddressType.IPv6, 'Tunnel DNS IPv6');
+    }
+    if ((platform == ConnectionPlatform.ios ||
+            platform == ConnectionPlatform.macos) &&
+        toJson()['apple']['dnsOverTls'] == true &&
+        dnsServerName.isEmpty) {
+      throw const FormatException('DNS over TLS requires a server name');
+    }
+  }
 
   /// Compiles for a real start. Inactive platform drafts remain in [toJson].
   TunJson toTun(ConnectionPlatform platform, {WindowsMode? windowsMode}) {
+    validateDns(platform, windowsMode: windowsMode);
     final policy = toJson();
     final tun = <String, dynamic>{
       'tunIPv4': tunIpv4Address,
@@ -163,10 +194,15 @@ final class PlatformPolicy {
   }
 
   WindowsVpnPolicy toWindowsPolicy() {
+    validateDns(ConnectionPlatform.windows, windowsMode: WindowsMode.msix);
     final policy = toJson();
     final windows = policy['windows'] as Map<String, dynamic>;
     final cidrs = (windows['excludedCidrs'] as List).cast<String>();
-    _validateExclusions(cidrs, ipv6: policy['ipv6Enabled'] as bool);
+    _validateExclusions(
+      cidrs,
+      dnsAddresses: [dnsIpv4Address, dnsIpv6Address],
+      ipv6: policy['ipv6Enabled'] as bool,
+    );
     return WindowsVpnPolicy(
       alwaysOn: windows['alwaysOn'] as bool,
       allowLocalNetwork: windows['allowLocalNetwork'] as bool,
@@ -177,6 +213,9 @@ final class PlatformPolicy {
 
 const _defaults = <String, dynamic>{
   'ipv6Enabled': true,
+  'dnsIpv4Address': '8.8.8.8',
+  'dnsIpv6Address': '2001:4860:4860::8888',
+  'dnsServerName': 'dns.google',
   'xrayOutboundInterfaceName': '',
   'android': {
     'appScope': 'all',
@@ -268,14 +307,17 @@ List<String> _appleExcludedRoutes(List<String> values, {required bool ipv6}) {
   return routes;
 }
 
-void _validateExclusions(List<String> values, {bool ipv6 = true}) {
+void _validateExclusions(
+  List<String> values, {
+  required List<String> dnsAddresses,
+  bool ipv6 = true,
+}) {
   if (values.length > 64) {
     throw const FormatException('Windows VPN allows at most 64 exclusions');
   }
   final seen = <String>{};
   final dns = [
-    InternetAddress(PlatformPolicy.dnsIpv4Address).rawAddress,
-    InternetAddress(PlatformPolicy.dnsIpv6Address).rawAddress,
+    for (final address in dnsAddresses) InternetAddress(address).rawAddress,
   ];
   for (final value in values) {
     final parts = value.split('/');

--- a/lib/service/advanced/policy_editor.dart
+++ b/lib/service/advanced/policy_editor.dart
@@ -68,6 +68,7 @@ class PolicyEditorService {
               .toList();
     }
     final policy = PlatformPolicy.fromJson(value);
+    policy.validateDns(platform, windowsMode: windowsMode);
     if (requiresInterface && policy.xrayOutboundInterfaceName.trim().isEmpty) {
       throw const FormatException('Network interface is required');
     }
@@ -128,6 +129,11 @@ class PolicyEditorService {
       final json = policy.toJson();
       final result = <String, dynamic>{
         'ipv6': policy.ipv6Enabled,
+        'dnsIpv4Address': policy.dnsIpv4Address,
+        if (policy.ipv6Enabled ||
+            (platform == ConnectionPlatform.windows &&
+                (windowsMode ?? windowsBuildMode) == WindowsMode.msix))
+          'dnsIpv6Address': policy.dnsIpv6Address,
         'log': json['log'],
       };
       if (platform == ConnectionPlatform.android) {
@@ -141,7 +147,9 @@ class PolicyEditorService {
         result['android'] = {'scope': scope, 'packages': packages};
       } else if (platform == ConnectionPlatform.ios ||
           platform == ConnectionPlatform.macos) {
-        result['apple'] = policy.toTun(platform).toJson();
+        final tun = policy.toTun(platform).toJson();
+        if (tun['enableDot'] != true) tun.remove('dnsServerName');
+        result['apple'] = tun;
       } else {
         result['interface'] = policy.xrayOutboundInterfaceName;
         if (platform == ConnectionPlatform.windows &&

--- a/lib/service/connect/compiler.dart
+++ b/lib/service/connect/compiler.dart
@@ -9,6 +9,7 @@ import 'package:onexray/service/connect/settings.dart';
 import 'package:onexray/service/connect/runtime_network_policy.dart';
 import 'package:onexray/service/connect/routing/region_catalog.dart';
 import 'package:onexray/service/connect/routing/custom/state.dart';
+import 'package:onexray/service/connect/routing/dns.dart';
 import 'package:onexray/service/servers/outbound/map.dart';
 import 'package:onexray/service/servers/outbound/state_db.dart';
 import 'package:onexray/service/shared/xray/runtime_inbounds.dart';
@@ -56,6 +57,8 @@ class RuntimeOptions {
   final int metricsPort;
   final int socksPort;
   final bool ipv6;
+  final String tunDnsIpv4Address;
+  final String tunDnsIpv6Address;
   final String interfaceName;
   final bool logEnabled;
   final bool logFilesSupported;
@@ -70,6 +73,8 @@ class RuntimeOptions {
     required this.metricsPort,
     required this.socksPort,
     this.ipv6 = true,
+    this.tunDnsIpv4Address = '8.8.8.8',
+    this.tunDnsIpv6Address = '2001:4860:4860::8888',
     this.interfaceName = '',
     this.logEnabled = false,
     this.logFilesSupported = true,
@@ -132,8 +137,8 @@ class ConnectionCompiler {
     return _rawRuntimeMap(value, options);
   }
 
-  static const dnsProxy = 'app-dns-proxy';
-  static const dnsDirect = 'app-dns-direct';
+  static const dnsProxy = RoutingDns.proxyTag;
+  static const dnsDirect = RoutingDns.directTag;
   static const dnsOutbound = 'dnsOut';
 
   /// The editor and runtime share these exact built-in rules and their order.
@@ -269,7 +274,6 @@ class ConnectionCompiler {
           directDomains.addAll(rule.domain ?? []);
         }
       }
-      final queryStrategy = options.ipv6 ? 'UseIP' : 'UseIPv4';
       final normal = XrayJson(
         env: XrayEnv(
           assetLocation: VpnConstants.datDir,
@@ -282,22 +286,14 @@ class ConnectionCompiler {
         policy: XrayPolicy(system: _runtimeStatsPolicy()),
         outbounds: outbounds,
         observatory: XrayObservatory(subjectSelector: []),
-        dns: XrayDns(
-          servers: [
-            XrayDnsServer(
-              address: '8.8.8.8',
-              tag: dnsProxy,
-              queryStrategy: queryStrategy,
-            ),
-            if (!allVpn)
-              XrayDnsServer(
-                address: '8.8.8.8',
-                tag: dnsDirect,
-                domains: directDomains.toList(),
-                skipFallback: true,
-                queryStrategy: queryStrategy,
-              ),
-          ],
+        dns: RoutingDns.compile(
+          directAddress: switch (settings.trafficMode) {
+            TrafficMode.allVpn => null,
+            TrafficMode.smart => settings.smart.effectiveDirectDnsAddress,
+            TrafficMode.custom => custom!.directDnsAddress.trim(),
+          },
+          directDomains: directDomains,
+          ipv6: options.ipv6,
         ),
         routing: XrayRouting(
           domainStrategy: allVpn ? 'AsIs' : 'IPIfNonMatch',
@@ -394,7 +390,10 @@ class ConnectionCompiler {
           ? ['198.18.0.1/15', if (options.ipv6) 'fc00::1/64']
           : null,
       dns: nativeTun
-          ? ['8.8.8.8', if (options.ipv6) '2001:4860:4860::8888']
+          ? [
+              options.tunDnsIpv4Address,
+              if (options.ipv6) options.tunDnsIpv6Address,
+            ]
           : null,
       autoSystemRoutingTable: nativeTun
           ? ['0.0.0.0/0', if (options.ipv6) '::/0']

--- a/lib/service/connect/preparation.dart
+++ b/lib/service/connect/preparation.dart
@@ -176,6 +176,8 @@ class ConnectionPreparation {
         socksPort: ports[0],
         metricsPort: ports[1],
         ipv6: policy.ipv6Enabled,
+        tunDnsIpv4Address: policy.dnsIpv4Address,
+        tunDnsIpv6Address: policy.dnsIpv6Address,
         interfaceName: policy.xrayOutboundInterfaceName,
         logEnabled: policy.logEnabled,
         logLevel: policy.logLevel,

--- a/lib/service/connect/routing/custom/document.dart
+++ b/lib/service/connect/routing/custom/document.dart
@@ -21,8 +21,8 @@ final class RoutingProfileDocument {
     _onlyKeys(
       document,
       allowMetadata
-          ? const {'name', 'outbounds', 'routing', 'geodata'}
-          : const {'outbounds', 'routing'},
+          ? const {'name', 'outbounds', 'routing', 'geodata', 'dns'}
+          : const {'outbounds', 'routing', 'dns'},
       'template',
     );
     final embeddedName = document['name'];
@@ -63,6 +63,20 @@ final class RoutingProfileDocument {
 // Do not silently discard fields the ordinary editor cannot represent.
 // Field values and rule semantics are validated by libXray when saving.
 void _checkEditableFields(Map<String, dynamic> document) {
+  if (document.containsKey('dns')) {
+    final dns = _object(document['dns'], 'dns');
+    _onlyKeys(dns, const {'servers'}, 'dns');
+    final servers = dns['servers'];
+    if (servers is! List) {
+      throw const FormatException('dns.servers must be an array');
+    }
+    for (var index = 0; index < servers.length; index++) {
+      _onlyKeys(_object(servers[index], 'dns.servers[$index]'), const {
+        'tag',
+        'address',
+      }, 'dns.servers[$index]');
+    }
+  }
   final routing = document.containsKey('routing')
       ? _object(document['routing'], 'routing')
       : <String, dynamic>{};

--- a/lib/service/connect/routing/custom/editor.dart
+++ b/lib/service/connect/routing/custom/editor.dart
@@ -197,6 +197,7 @@ class CustomRoutingEditorService {
   ) {
     Object semantic(RoutingProfileState state) => {
       'entries': state.entryCount,
+      'directDnsAddress': state.directDnsAddress.trim(),
       'rules': [
         for (final rule in state.rules) {...rule.toJson()}..remove('ruleTag'),
       ],

--- a/lib/service/connect/routing/custom/service.dart
+++ b/lib/service/connect/routing/custom/service.dart
@@ -5,6 +5,7 @@ import 'package:onexray/core/pigeon/host_api.dart';
 import 'package:onexray/service/advanced/xray/geodata/service.dart';
 import 'package:onexray/service/connect/routing/custom/state.dart';
 import 'package:onexray/service/connect/routing/custom/state_db.dart';
+import 'package:onexray/service/connect/routing/dns.dart';
 import 'package:onexray/service/shared/xray/runtime_outbounds.dart';
 import 'package:onexray/service/shared/xray/validation.dart';
 
@@ -25,6 +26,13 @@ class CustomRoutingService {
     Future<String> Function(String)? testXray,
   }) => GeoDataService().withFiles(() async {
     final config = state.xrayJson;
+    config.dns = RoutingDns.compile(
+      directAddress: state.directDnsAddress.trim(),
+      directDomains: [
+        for (final rule in state.rules)
+          if (rule.action == RoutingRuleAction.direct) ...rule.domain,
+      ],
+    );
     final tags = [for (var i = 0; i < state.entryCount; i++) 'app-entry-$i'];
     config.outbounds = [
       for (final tag in tags) createFreedomOutbound(tag: tag).toJson(),

--- a/lib/service/connect/routing/custom/state.dart
+++ b/lib/service/connect/routing/custom/state.dart
@@ -1,4 +1,5 @@
 import 'package:onexray/core/model/xray_json.dart';
+import 'package:onexray/service/connect/routing/dns.dart';
 import 'package:onexray/core/tools/json.dart';
 
 enum RoutingRuleAction { proxy, direct, block }
@@ -85,12 +86,14 @@ final class RoutingProfileState {
   final int? id;
   final String name;
   final int entryCount;
+  final String directDnsAddress;
   final List<RoutingRuleState> rules;
 
   RoutingProfileState({
     this.id,
     required this.name,
     this.entryCount = 1,
+    this.directDnsAddress = RoutingDns.defaultAddress,
     Iterable<RoutingRuleState> rules = const [],
   }) : rules = List.unmodifiable(rules);
 
@@ -102,7 +105,6 @@ final class RoutingProfileState {
     if (xrayJson.env != null ||
         xrayJson.geodata != null ||
         xrayJson.log != null ||
-        xrayJson.dns != null ||
         xrayJson.inbounds != null ||
         xrayJson.policy != null ||
         xrayJson.stats != null ||
@@ -126,6 +128,7 @@ final class RoutingProfileState {
       id: id,
       name: name,
       entryCount: outbounds.length,
+      directDnsAddress: _directDnsAddress(xrayJson.dns),
       rules: [
         for (final rule in xrayJson.routing?.rules ?? const [])
           RoutingRuleState.fromXrayJson(rule),
@@ -138,6 +141,14 @@ final class RoutingProfileState {
   XrayJson get xrayJson {
     validate();
     return XrayJson(
+      dns: XrayDns(
+        servers: [
+          XrayDnsServer(
+            tag: RoutingDns.directTag,
+            address: directDnsAddress.trim(),
+          ),
+        ],
+      ),
       outbounds: [
         for (var index = 0; index < entryCount; index++) <String, dynamic>{},
       ],
@@ -155,11 +166,13 @@ final class RoutingProfileState {
     bool clearId = false,
     String? name,
     int? entryCount,
+    String? directDnsAddress,
     Iterable<RoutingRuleState>? rules,
   }) => RoutingProfileState(
     id: clearId ? null : id ?? this.id,
     name: name ?? this.name,
     entryCount: entryCount ?? this.entryCount,
+    directDnsAddress: directDnsAddress ?? this.directDnsAddress,
     rules: rules ?? this.rules,
   );
 
@@ -174,6 +187,29 @@ final class RoutingProfileState {
       throw const FormatException('Custom routing requires 1–3 entry nodes');
     }
   }
+}
+
+String _directDnsAddress(XrayDns? dns) {
+  if (dns == null) return RoutingDns.defaultAddress;
+  final servers = dns.servers;
+  if (servers == null || servers.length != 1) {
+    throw const FormatException(
+      'Custom routing requires one tagged direct DNS server',
+    );
+  }
+  final server = servers
+      .where((server) => server.tag == RoutingDns.directTag)
+      .firstOrNull;
+  if (server == null ||
+      server.address == null ||
+      server.domains != null ||
+      server.skipFallback != null ||
+      server.queryStrategy != null) {
+    throw const FormatException(
+      'Custom DNS supports only app-dns-direct with an address',
+    );
+  }
+  return server.address!;
 }
 
 Object? _copyValue(Object? value) =>

--- a/lib/service/connect/routing/dns.dart
+++ b/lib/service/connect/routing/dns.dart
@@ -1,0 +1,32 @@
+import 'package:onexray/core/model/xray_json.dart';
+
+abstract final class RoutingDns {
+  static const defaultAddress = '8.8.8.8';
+  static const proxyTag = 'app-dns-proxy';
+  static const directTag = 'app-dns-direct';
+
+  static XrayDns compile({
+    String? directAddress,
+    Iterable<String> directDomains = const [],
+    bool ipv6 = true,
+  }) {
+    final queryStrategy = ipv6 ? 'UseIP' : 'UseIPv4';
+    return XrayDns(
+      servers: [
+        XrayDnsServer(
+          address: defaultAddress,
+          tag: proxyTag,
+          queryStrategy: queryStrategy,
+        ),
+        if (directAddress != null)
+          XrayDnsServer(
+            address: directAddress,
+            tag: directTag,
+            domains: directDomains.toSet().toList(),
+            skipFallback: true,
+            queryStrategy: queryStrategy,
+          ),
+      ],
+    );
+  }
+}

--- a/lib/service/connect/routing/smart/editor.dart
+++ b/lib/service/connect/routing/smart/editor.dart
@@ -1,5 +1,8 @@
 import 'package:collection/collection.dart';
 import 'package:onexray/core/db/database/database.dart';
+import 'package:onexray/core/errors/failure.dart';
+import 'package:onexray/core/model/xray_json.dart';
+import 'package:onexray/core/pigeon/host_api.dart';
 import 'package:onexray/service/connect/compiler.dart';
 import 'package:onexray/service/connect/coordinator.dart';
 import 'package:onexray/service/connect/runtime.dart';
@@ -7,6 +10,9 @@ import 'package:onexray/service/connect/runtime_host.dart';
 import 'package:onexray/service/connect/settings.dart';
 import 'package:onexray/service/connect/routing/custom/geodata_suggestions.dart';
 import 'package:onexray/service/connect/routing/region_catalog.dart';
+import 'package:onexray/service/connect/routing/dns.dart';
+import 'package:onexray/service/shared/xray/runtime_outbounds.dart';
+import 'package:onexray/service/shared/xray/validation.dart';
 
 class SmartRoutingEditorDraft {
   final ConnectionConfiguration configuration;
@@ -26,11 +32,13 @@ class SmartRoutingEditorService {
   final AppDatabase db;
   final ConnectionCoordinator coordinator;
   final Future<RegionCatalog> Function()? loadRegions;
+  final Future<String> Function(String)? testXray;
 
   SmartRoutingEditorService({
     AppDatabase? database,
     ConnectionCoordinator? coordinator,
     this.loadRegions,
+    this.testXray,
   }) : db = database ?? AppDatabase(),
        coordinator = coordinator ?? ConnectionCoordinator.instance;
 
@@ -70,6 +78,10 @@ class SmartRoutingEditorService {
     required SmartRoutingSettings smart,
     required Future<bool> Function() confirmReconnect,
   }) async {
+    smart = SmartRoutingSettings.fromJson({
+      ...smart.toJson(),
+      'directDnsAddress': smart.directDnsAddress.trim(),
+    });
     await coordinator.initialize();
     await coordinator.refresh();
     if ((await coordinator.configuration).encode() != original.encode()) {
@@ -98,6 +110,12 @@ class SmartRoutingEditorService {
       affectsRuntime: affectsRuntime,
       allowReconnect: allowReconnect,
       expectedConfiguration: original.encode(),
+      validateAssets:
+          smart.directDns &&
+              (!connection.smart.directDns ||
+                  smart.directDnsAddress != connection.smart.directDnsAddress)
+          ? () => _validateDns(smart.directDnsAddress)
+          : null,
       writeAssets: () async {
         if (smart.finalExitId == null) return;
         if ((connection.selection.kind == SelectionKind.server &&
@@ -108,6 +126,24 @@ class SmartRoutingEditorService {
       },
     );
     return true;
+  }
+
+  Future<void> _validateDns(String address) async {
+    final error = await (testXray ?? AppHostApi().testXray)(
+      XrayValidation.normal(
+        XrayJson(
+          dns: RoutingDns.compile(directAddress: address),
+          outbounds: [createFreedomOutbound(tag: 'direct').toJson()],
+        ),
+      ),
+    );
+    if (error.isNotEmpty) {
+      throw AppFailure(
+        FailureCategory.configuration,
+        'xrayValidation',
+        cause: error,
+      );
+    }
   }
 
   static bool sameRuntime(
@@ -130,6 +166,7 @@ class SmartRoutingEditorService {
                   if (rule.outboundTag == 'direct') ...?rule.domain,
               ]
             : <String>[],
+        'directDnsAddress': value.effectiveDirectDnsAddress,
         'entryCount': original.selection.kind == SelectionKind.server
             ? 1
             : value.entryCount,

--- a/lib/service/connect/runtime_host.dart
+++ b/lib/service/connect/runtime_host.dart
@@ -223,11 +223,11 @@ class ConnectionRuntimeHost {
             )
           : null,
       windowsNetworkSettings: windows
-          ? const WindowsVpnNetworkSettings(
+          ? WindowsVpnNetworkSettings(
               ipv4Address: PlatformPolicy.tunIpv4Address,
               ipv6Address: PlatformPolicy.tunIpv6Address,
-              dnsIpv4Address: PlatformPolicy.dnsIpv4Address,
-              dnsIpv6Address: PlatformPolicy.dnsIpv6Address,
+              dnsIpv4Address: policy.dnsIpv4Address,
+              dnsIpv6Address: policy.dnsIpv6Address,
             )
           : null,
       windowsPolicy: windows

--- a/lib/service/connect/settings.dart
+++ b/lib/service/connect/settings.dart
@@ -1,3 +1,5 @@
+import 'package:onexray/service/connect/routing/dns.dart';
+
 enum ConnectionPlatform { ios, macos, android, windows, linux }
 
 enum SelectionKind { automatic, region, source, server }
@@ -48,6 +50,7 @@ class SmartRoutingSettings {
   final bool directApple;
   final bool directWindows;
   final bool directDns;
+  final String directDnsAddress;
   final bool blockAds;
 
   SmartRoutingSettings({
@@ -58,6 +61,7 @@ class SmartRoutingSettings {
     this.directApple = true,
     this.directWindows = true,
     this.directDns = true,
+    this.directDnsAddress = RoutingDns.defaultAddress,
     this.blockAds = false,
   }) : directRegions = List.unmodifiable(directRegions) {
     if (entryCount < 1 || entryCount > 3) {
@@ -75,6 +79,8 @@ class SmartRoutingSettings {
         directApple: value['directApple'] as bool? ?? true,
         directWindows: value['directWindows'] as bool? ?? true,
         directDns: value['directDns'] as bool? ?? true,
+        directDnsAddress:
+            value['directDnsAddress'] as String? ?? RoutingDns.defaultAddress,
         blockAds: value['blockAds'] as bool? ?? false,
       );
 
@@ -86,8 +92,12 @@ class SmartRoutingSettings {
     'directApple': directApple,
     'directWindows': directWindows,
     'directDns': directDns,
+    'directDnsAddress': directDnsAddress,
     'blockAds': blockAds,
   };
+
+  String get effectiveDirectDnsAddress =>
+      directDns ? directDnsAddress.trim() : RoutingDns.defaultAddress;
 }
 
 /// Retains the normal selection while Raw is active. The coordinator stores

--- a/test/pages/connect/routing/custom_ui_test.dart
+++ b/test/pages/connect/routing/custom_ui_test.dart
@@ -281,6 +281,13 @@ void main() {
         }),
       );
       final selected = controller.state.selectedRuleKey;
+      controller.setDirectDnsAddress('1.1.1.1');
+      expect(controller.profileState.directDnsAddress, '1.1.1.1');
+      expect(jsonDecode(controller.previewState!.encode())['dns'], {
+        'servers': [
+          {'tag': 'app-dns-direct', 'address': '1.1.1.1'},
+        ],
+      });
       controller.reorder(1, 0);
       expect(controller.state.rules.map((rule) => rule.ruleTag), [
         'B',
@@ -293,6 +300,7 @@ void main() {
       expect(controller.state.selectedRuleKey, controller.state.ruleKeys.first);
       controller.setInlineEditing(true);
       expect(controller.inlineRule!.name.text, 'A');
+      expect(controller.profileState.directDnsAddress, '1.1.1.1');
       controller.inlineRule!.name.text = 'A edited';
       controller.inlineRule!.domains.single.text.text = 'edited.example';
       controller.inlineRule!.port.text = '65536';

--- a/test/pages/shared/widgets/dns_text_field_test.dart
+++ b/test/pages/shared/widgets/dns_text_field_test.dart
@@ -1,0 +1,86 @@
+import 'package:material_ui/material_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onexray/l10n/localizations/app_localizations.dart';
+import 'package:onexray/pages/shared/widgets/dns_text_field.dart';
+import 'package:onexray/pages/theme/theme.dart';
+import 'package:onexray/service/settings/language/locale.dart';
+
+void main() {
+  for (final locale in AppLocalizations.supportedLocales) {
+    for (final width in [390.0, 1200.0]) {
+      testWidgets('DNS inputs support edits and reset in $locale at $width', (
+        tester,
+      ) async {
+        tester.view.devicePixelRatio = 1;
+        tester.view.physicalSize = Size(width, 900);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        addTearDown(tester.view.resetPhysicalSize);
+        var value = '1.1.1.1';
+        String? changed;
+        Widget app() => MaterialApp(
+          theme: AppTheme.material(Brightness.light, mobile: width < 600),
+          locale: locale,
+          localizationsDelegates: AppLocalePolicy.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                final l = AppLocalizations.of(context)!;
+                return SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    spacing: 18,
+                    children: [
+                      DnsTextField(
+                        label: l.routingLocalDnsAddress,
+                        value: value,
+                        onChanged: (text) => changed = text,
+                      ),
+                      DnsTextField(
+                        label: l.prototypeIpv4Dns,
+                        value: '8.8.8.8',
+                        onChanged: (_) {},
+                      ),
+                      DnsTextField(
+                        label: l.prototypeIpv6Dns,
+                        value: '2001:4860:4860::8888',
+                        onChanged: (_) {},
+                      ),
+                      DnsTextField(
+                        label: l.prototypeDomain,
+                        value: 'dns.google',
+                        hint: l.tunnelDnsServerNameHint,
+                        onChanged: (_) {},
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+        await tester.pumpWidget(app());
+        await tester.pumpAndSettle();
+        for (final input in tester.widgetList<TextField>(
+          find.byType(TextField),
+        )) {
+          expect(input.textDirection, TextDirection.ltr);
+          expect(input.autocorrect, false);
+        }
+        await tester.enterText(find.byType(TextField).first, '9.9.9.9');
+        expect(changed, '9.9.9.9');
+        value = '8.8.8.8';
+        await tester.pumpWidget(app());
+        await tester.pumpAndSettle();
+        expect(
+          tester
+              .widget<TextField>(find.byType(TextField).first)
+              .controller!
+              .text,
+          value,
+        );
+        expect(tester.takeException(), isNull);
+      });
+    }
+  }
+}

--- a/test/service/advanced/platform_policy_test.dart
+++ b/test/service/advanced/platform_policy_test.dart
@@ -5,6 +5,94 @@ import 'package:onexray/service/connect/settings.dart';
 
 void main() {
   test(
+    'configured tunnel DNS survives storage and reaches native parameters',
+    () {
+      for (final platform in ConnectionPlatform.values) {
+        final policy = PlatformPolicy.fromJson({
+          'xrayOutboundInterfaceName': 'Ethernet',
+          'dnsIpv4Address': ' 1.1.1.1 ',
+          'dnsIpv6Address': '2606:4700:4700::1111',
+          'dnsServerName': 'cloudflare-dns.com',
+          'apple': {'dnsOverTls': true},
+        });
+        final restored = PlatformPolicy.fromJson(policy.toJson());
+        final tun = restored.toTun(platform);
+        expect(tun.tunDnsIPv4, '1.1.1.1');
+        expect(tun.tunDnsIPv6, '2606:4700:4700::1111');
+        expect(tun.dnsServerName, 'cloudflare-dns.com');
+        expect(restored.dnsIpv4Address, '1.1.1.1');
+        expect(tun.tunIPv4, '198.18.0.1');
+      }
+    },
+  );
+
+  test('only effective native DNS fields are validated', () {
+    for (final value in [
+      '',
+      'dns.example.com',
+      '::1',
+      '1.1.1.1:53',
+      'https://1.1.1.1',
+    ]) {
+      final policy = PlatformPolicy.fromJson({'dnsIpv4Address': value});
+      expect(
+        () => policy.toTun(ConnectionPlatform.android),
+        throwsFormatException,
+      );
+    }
+    for (final value in ['', '1.1.1.1', '[2001:db8::1]', 'fe80::1%en0']) {
+      final policy = PlatformPolicy.fromJson({'dnsIpv6Address': value});
+      expect(() => policy.toTun(ConnectionPlatform.ios), throwsFormatException);
+    }
+    final inactive = PlatformPolicy.fromJson({
+      'ipv6Enabled': false,
+      'dnsIpv6Address': '',
+      'dnsServerName': '',
+      'xrayOutboundInterfaceName': 'Ethernet',
+    });
+    expect(inactive.toTun(ConnectionPlatform.ios).tunDnsIPv6, isNull);
+    expect(
+      () => inactive.toTun(
+        ConnectionPlatform.windows,
+        windowsMode: WindowsMode.exe,
+      ),
+      returnsNormally,
+    );
+    expect(() => inactive.toWindowsPolicy(), throwsFormatException);
+    final dot = PlatformPolicy.fromJson({
+      ...inactive.toJson(),
+      'apple': {'dnsOverTls': true},
+    });
+    expect(() => dot.toTun(ConnectionPlatform.ios), throwsFormatException);
+    expect(() => dot.toTun(ConnectionPlatform.android), returnsNormally);
+  });
+
+  test('Windows exclusions protect configured DNS instead of old defaults', () {
+    final value = {
+      'dnsIpv4Address': '1.1.1.1',
+      'dnsIpv6Address': '2606:4700:4700::1111',
+      'windows': {
+        'excludedCidrs': ['8.8.8.8/32', '2001:4860:4860::8888/128'],
+      },
+    };
+    expect(
+      PlatformPolicy.fromJson(value).toWindowsPolicy().excludedCidrs,
+      hasLength(2),
+    );
+    for (final cidr in ['1.1.1.0/24', '2606:4700:4700::/64']) {
+      expect(
+        () => PlatformPolicy.fromJson({
+          ...value,
+          'windows': {
+            'excludedCidrs': [cidr],
+          },
+        }).toWindowsPolicy(),
+        throwsFormatException,
+      );
+    }
+  });
+
+  test(
     'defaults contain no demo selections and compile fixed runtime values',
     () {
       final policy = PlatformPolicy.defaults();
@@ -58,7 +146,7 @@ void main() {
       final tun = policy.toTun(platform);
       expect(tun.enableIPv6, false);
       expect(tun.tunIPv4, PlatformPolicy.tunIpv4Address);
-      expect(tun.tunDnsIPv4, PlatformPolicy.dnsIpv4Address);
+      expect(tun.tunDnsIPv4, policy.dnsIpv4Address);
       expect(tun.tunIPv6, isNull);
       expect(tun.tunDnsIPv6, isNull);
       expect(tun.toJson(), isNot(contains('tunIPv6')));
@@ -247,7 +335,7 @@ void main() {
     for (final platform in [ConnectionPlatform.ios, ConnectionPlatform.macos]) {
       final policy = PlatformPolicy.fromJson(value);
       expect(policy.toTun(platform).excludedRoutes, cidrs);
-      expect(policy.toTun(platform).tunDnsIPv4, PlatformPolicy.dnsIpv4Address);
+      expect(policy.toTun(platform).tunDnsIPv4, policy.dnsIpv4Address);
       expect(policy.toJson()['apple']['excludedCidrs'], cidrs);
     }
     for (final platform in [

--- a/test/service/advanced/policy_editor_test.dart
+++ b/test/service/advanced/policy_editor_test.dart
@@ -16,6 +16,72 @@ import 'package:onexray/service/connect/runtime_host.dart';
 import 'package:onexray/service/connect/settings.dart';
 
 void main() {
+  test('reconnect comparisons include only effective DNS settings', () {
+    final original = PlatformPolicy.fromJson({
+      'xrayOutboundInterfaceName': 'Ethernet',
+    });
+    for (final platform in ConnectionPlatform.values) {
+      for (final field in ['dnsIpv4Address', 'dnsIpv6Address']) {
+        final changed = PlatformPolicy.fromJson({
+          ...original.toJson(),
+          field: field == 'dnsIpv4Address' ? '1.1.1.1' : '2606:4700:4700::1111',
+        });
+        expect(
+          PolicyEditorService.sameRuntime(original, changed, platform),
+          false,
+        );
+      }
+      final renamed = PlatformPolicy.fromJson({
+        ...original.toJson(),
+        'dnsServerName': 'cloudflare-dns.com',
+      });
+      expect(
+        PolicyEditorService.sameRuntime(original, renamed, platform),
+        true,
+      );
+      final off = PlatformPolicy.fromJson({
+        ...original.toJson(),
+        'ipv6Enabled': false,
+      });
+      final offChanged = PlatformPolicy.fromJson({
+        ...off.toJson(),
+        'dnsIpv6Address': '2606:4700:4700::1111',
+      });
+      expect(
+        PolicyEditorService.sameRuntime(
+          off,
+          offChanged,
+          platform,
+          windowsMode: WindowsMode.exe,
+        ),
+        true,
+      );
+      if (platform == ConnectionPlatform.windows) {
+        expect(
+          PolicyEditorService.sameRuntime(
+            off,
+            offChanged,
+            platform,
+            windowsMode: WindowsMode.msix,
+          ),
+          false,
+        );
+      }
+      if (platform == ConnectionPlatform.ios ||
+          platform == ConnectionPlatform.macos) {
+        final dot = PlatformPolicy.fromJson({
+          ...original.toJson(),
+          'apple': {'dnsOverTls': true},
+        });
+        final changed = PlatformPolicy.fromJson({
+          ...dot.toJson(),
+          'dnsServerName': 'cloudflare-dns.com',
+        });
+        expect(PolicyEditorService.sameRuntime(dot, changed, platform), false);
+      }
+    }
+  });
+
   late AppDatabase db;
   late ConnectionCoordinator coordinator;
   late HostConnection host;
@@ -152,6 +218,9 @@ void main() {
       );
       final seed = await service.load();
       seed.policy['ipv6Enabled'] = false;
+      seed.policy['dnsIpv4Address'] = '1.1.1.1';
+      seed.policy['dnsIpv6Address'] = '2606:4700:4700::1111';
+      seed.policy['dnsServerName'] = 'cloudflare-dns.com';
       seed.policy['android']['appScope'] = 'excluded';
       seed.policy['android']['excludedAppPackageNames'] = [
         'com.example.bypass',

--- a/test/service/connect/compiler_test.dart
+++ b/test/service/connect/compiler_test.dart
@@ -31,6 +31,8 @@ RuntimeOptions options({
   WindowsMode windowsMode = WindowsMode.exe,
   bool ipv6 = true,
   String interfaceName = '',
+  String tunDnsIpv4Address = '8.8.8.8',
+  String tunDnsIpv6Address = '2001:4860:4860::8888',
 }) => RuntimeOptions(
   platform: platform,
   windowsMode: windowsMode,
@@ -39,6 +41,8 @@ RuntimeOptions options({
   socksPort: 18187,
   ipv6: ipv6,
   interfaceName: interfaceName,
+  tunDnsIpv4Address: tunDnsIpv4Address,
+  tunDnsIpv6Address: tunDnsIpv6Address,
 );
 
 ResolvedServer node(int id, {String? address}) => ResolvedServer(
@@ -52,6 +56,107 @@ ResolvedServer node(int id, {String? address}) => ResolvedServer(
 );
 
 void main() {
+  test('routing DNS addresses are independent from proxy and tunnel DNS', () {
+    for (final mode in TrafficMode.values) {
+      final compiled = ConnectionCompiler.compile(
+        settings: ConnectionSettings(
+          trafficMode: mode,
+          smart: SmartRoutingSettings(directDnsAddress: '1.1.1.1'),
+        ),
+        entries: [node(1)],
+        custom: RoutingProfileState(
+          name: 'Custom',
+          directDnsAddress: '9.9.9.9',
+          rules: [
+            RoutingRuleState(
+              domain: ['domain:example.com'],
+              action: RoutingRuleAction.direct,
+            ),
+          ],
+        ),
+        regions: catalog,
+        options: options(ipv6: false, tunDnsIpv4Address: '192.0.2.53'),
+      );
+      final servers = compiled.config['dns']['servers'] as List;
+      expect(servers.first, {
+        'tag': 'app-dns-proxy',
+        'address': '8.8.8.8',
+        'queryStrategy': 'UseIPv4',
+      });
+      expect(servers.length, mode == TrafficMode.allVpn ? 1 : 2);
+      if (mode != TrafficMode.allVpn) {
+        final direct = servers.singleWhere(
+          (server) => server['tag'] == 'app-dns-direct',
+        );
+        expect(
+          direct['address'],
+          mode == TrafficMode.smart ? '1.1.1.1' : '9.9.9.9',
+        );
+        expect(direct['skipFallback'], true);
+        expect(direct['queryStrategy'], 'UseIPv4');
+        expect(direct['domains'], isNotEmpty);
+      }
+      expect(
+        jsonDecode(compiled.validationJson)['dns'],
+        compiled.config['dns'],
+      );
+    }
+    final disabled =
+        ConnectionCompiler.compile(
+              settings: ConnectionSettings(
+                smart: SmartRoutingSettings(
+                  directDns: false,
+                  directDnsAddress: '1.1.1.1',
+                ),
+              ),
+              entries: [node(1)],
+              regions: catalog,
+              options: options(),
+            ).config['dns']['servers']
+            as List;
+    expect(disabled.last['address'], '8.8.8.8');
+    expect(disabled.last['domains'], isEmpty);
+  });
+
+  test('native TUN uses configured DNS in normal and Raw without replacing Raw DNS', () {
+    for (final platform in [
+      ConnectionPlatform.windows,
+      ConnectionPlatform.linux,
+    ]) {
+      for (final ipv6 in [false, true]) {
+        for (final raw in [false, true]) {
+          final compiled = ConnectionCompiler.compile(
+            settings: ConnectionSettings(expert: raw),
+            entries: raw ? [] : [node(1)],
+            raw: raw
+                ? {
+                    'outbounds': [
+                      {'protocol': 'freedom'},
+                    ],
+                    'dns': {
+                      'servers': ['9.9.9.9'],
+                    },
+                  }
+                : null,
+            regions: catalog,
+            options: options(
+              platform: platform,
+              interfaceName: 'Ethernet',
+              ipv6: ipv6,
+              tunDnsIpv4Address: '192.0.2.53',
+              tunDnsIpv6Address: '2001:db8::53',
+            ),
+          );
+          expect(compiled.config['inbounds'].first['settings']['dns'], [
+            '192.0.2.53',
+            if (ipv6) '2001:db8::53',
+          ]);
+          if (raw) expect(compiled.config['dns']['servers'], ['9.9.9.9']);
+        }
+      }
+    }
+  });
+
   test('normal preflight uses real chains, routing and DNS without runtime resources', () {
     final plan = ConnectionCompiler.compile(
       settings: ConnectionSettings(

--- a/test/service/connect/routing/custom/editor_test.dart
+++ b/test/service/connect/routing/custom/editor_test.dart
@@ -37,6 +37,27 @@ RoutingProfileState _state(
 );
 
 void main() {
+  test(
+    'direct DNS changes are runtime changes independent of profile naming',
+    () {
+      final before = _state('Route');
+      expect(
+        CustomRoutingEditorService.sameRouting(
+          before,
+          before.copyWith(name: 'Renamed'),
+        ),
+        true,
+      );
+      expect(
+        CustomRoutingEditorService.sameRouting(
+          before,
+          before.copyWith(directDnsAddress: '1.1.1.1'),
+        ),
+        false,
+      );
+    },
+  );
+
   late AppDatabase db;
   setUp(() {
     db = AppDatabase.forTesting(NativeDatabase.memory());

--- a/test/service/connect/routing/custom/service_test.dart
+++ b/test/service/connect/routing/custom/service_test.dart
@@ -14,6 +14,7 @@ void main() {
     final state = RoutingProfileState(
       name: 'Route',
       entryCount: 3,
+      directDnsAddress: '1.1.1.1',
       rules: [RoutingRuleState(port: 0, network: 'TCP')],
     );
     final source = state.encode();
@@ -22,6 +23,9 @@ void main() {
     Future<String> check(String text) async {
       calls++;
       final config = jsonDecode(text);
+      expect(config['dns']['servers'].last['address'], '1.1.1.1');
+      expect(config['dns']['servers'].last['tag'], 'app-dns-direct');
+      expect(config['dns']['servers'].last['skipFallback'], true);
       expect(config['env']['xray.location.asset'], VpnConstants.datDir);
       expect(config['outbounds'], [
         for (var i = 0; i < 3; i++)
@@ -77,6 +81,7 @@ void main() {
       final service = CustomRoutingService(database);
       final state = RoutingProfileState(
         name: 'One',
+        directDnsAddress: '9.9.9.9',
         rules: [
           RoutingRuleState(
             ruleTag: 'Example',
@@ -89,12 +94,18 @@ void main() {
       final row = (await database.routingProfileDao.searchRow(id))!;
       final stored = jsonDecode(utf8.decode(base64Decode(row.data))) as Map;
       expect(stored['outbounds'], [{}]);
+      expect(stored['dns'], {
+        'servers': [
+          {'tag': 'app-dns-direct', 'address': '9.9.9.9'},
+        ],
+      });
       expect(stored.containsKey('name'), false);
       expect(stored.containsKey('geodata'), false);
       final roundTrip = CustomRoutingService.read(row);
       expect(roundTrip.id, id);
       expect(roundTrip.name, 'One');
       expect(roundTrip.entryCount, 1);
+      expect(roundTrip.directDnsAddress, '9.9.9.9');
       expect(roundTrip.xrayJson.routing!.domainStrategy, 'IPIfNonMatch');
       expect(stored['routing']['domainStrategy'], 'IPIfNonMatch');
       expect(roundTrip.rules.single.toJson(), state.rules.single.toJson());

--- a/test/service/connect/routing/custom/state_test.dart
+++ b/test/service/connect/routing/custom/state_test.dart
@@ -6,6 +6,61 @@ import 'package:onexray/service/connect/routing/custom/document.dart';
 import 'package:onexray/service/connect/routing/custom/state.dart';
 
 void main() {
+  test('tagged direct DNS round trips with only native editable fields', () {
+    final source = _document();
+    source['dns'] = {
+      'servers': [
+        {'address': '1.1.1.1', 'tag': 'app-dns-direct'},
+      ],
+    };
+    final state = RoutingProfileDocument.parse(jsonEncode(source)).state;
+    expect(state.directDnsAddress, '1.1.1.1');
+    final edited = state.copyWith(directDnsAddress: '9.9.9.9');
+    expect(jsonDecode(edited.encode())['dns'], {
+      'servers': [
+        {'tag': 'app-dns-direct', 'address': '9.9.9.9'},
+      ],
+    });
+    expect(
+      RoutingProfileDocument.parse(
+        edited.encode(),
+        allowMetadata: false,
+      ).state.directDnsAddress,
+      '9.9.9.9',
+    );
+    expect(
+      RoutingProfileDocument.parse(jsonEncode(_document()))
+          .state
+          .directDnsAddress,
+      '8.8.8.8',
+    );
+    for (final servers in [
+      [],
+      ['1.1.1.1'],
+      [
+        {'address': '1.1.1.1'},
+      ],
+      [
+        {'tag': 'app-dns-proxy', 'address': '1.1.1.1'},
+      ],
+      [
+        for (var i = 0; i < 2; i++)
+          {'tag': 'app-dns-direct', 'address': '1.1.1.1'},
+      ],
+      [
+        {'tag': 'app-dns-direct', 'address': '1.1.1.1', 'domains': []},
+      ],
+      [
+        {'tag': 'app-dns-direct', 'address': '1.1.1.1', 'port': 53},
+      ],
+    ]) {
+      _reject({
+        ..._document(),
+        'dns': {'servers': servers},
+      });
+    }
+  });
+
   test('projects the supported Xray routing fields into editable state', () {
     final source = _document(2);
     source['name'] = '  My routes  ';
@@ -37,6 +92,11 @@ void main() {
     expect(state.xrayJson.routing!.domainStrategy, 'IPIfNonMatch');
     expect(state.rules.map((rule) => rule.toJson()), [first, second, third]);
     expect(jsonDecode(state.encode()), {
+      'dns': {
+        'servers': [
+          {'tag': 'app-dns-direct', 'address': '8.8.8.8'},
+        ],
+      },
       'routing': {
         'domainStrategy': 'IPIfNonMatch',
         'rules': [first, second, third],
@@ -54,6 +114,11 @@ void main() {
     expect(state.rules.single.domain, ['domain:example.com']);
     expect(() => state.rules.add(rule), throwsUnsupportedError);
     expect(XrayJson.fromJson(jsonDecode(state.encode())).toJson(), {
+      'dns': {
+        'servers': [
+          {'tag': 'app-dns-direct', 'address': '8.8.8.8'},
+        ],
+      },
       'routing': {
         'domainStrategy': 'IPIfNonMatch',
         'rules': [

--- a/test/service/connect/routing/smart/editor_test.dart
+++ b/test/service/connect/routing/smart/editor_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:onexray/core/db/database/database.dart';
+import 'package:onexray/core/errors/failure.dart';
 import 'package:onexray/core/pigeon/messages.g.dart';
 import 'package:onexray/core/pigeon/model.dart';
 import 'package:onexray/service/connect/compiler.dart';
@@ -30,11 +31,82 @@ RegionCatalog _regions() => RegionCatalog.fromJson(
 );
 
 void main() {
+  test(
+    'Smart keeps legacy defaults and reconnects only for effective DNS changes',
+    () {
+      expect(SmartRoutingSettings.fromJson({}).directDnsAddress, '8.8.8.8');
+      for (final enabled in [false, true]) {
+        final before = SmartRoutingSettings(
+          directDns: enabled,
+          directDnsAddress: '1.1.1.1',
+        );
+        final after = SmartRoutingSettings.fromJson({
+          ...before.toJson(),
+          'directDnsAddress': '9.9.9.9',
+        });
+        expect(after.directDnsAddress, '9.9.9.9');
+        expect(
+          SmartRoutingEditorService.sameRuntime(
+            ConnectionSettings(smart: before),
+            after,
+            _regions(),
+          ),
+          !enabled,
+        );
+      }
+    },
+  );
+
   late AppDatabase db;
   setUp(() {
     db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
   });
+
+  test(
+    'Smart validates an edited DNS address with libXray before saving',
+    () async {
+      final coordinator = await _initialize(
+        ConnectionCoordinator(
+          database: db,
+          inspect: (_) async => const HostConnection(VpnStatus.disconnected),
+        ),
+      );
+      final original = await coordinator.configuration;
+      var coreError = 'Invalid DNS address';
+      var calls = 0;
+      final service = SmartRoutingEditorService(
+        database: db,
+        coordinator: coordinator,
+        loadRegions: () async => _regions(),
+        testXray: (text) async {
+          calls++;
+          final json = jsonDecode(text);
+          expect(json['dns']['servers'].last['tag'], 'app-dns-direct');
+          expect(json['dns']['servers'].last['address'], '1.1.1.1');
+          expect(json.containsKey('inbounds'), false);
+          return coreError;
+        },
+      );
+      Future<bool> save() => service.save(
+        original: original,
+        smart: SmartRoutingSettings(directDnsAddress: ' 1.1.1.1 '),
+        confirmReconnect: () async => throw StateError('Must not reconnect'),
+      );
+      await expectLater(
+        save(),
+        throwsA(isA<AppFailure>().having((e) => e.cause, 'cause', coreError)),
+      );
+      expect((await coordinator.configuration).encode(), original.encode());
+      coreError = '';
+      expect(await save(), true);
+      expect(
+        (await coordinator.configuration).connection.smart.directDnsAddress,
+        '1.1.1.1',
+      );
+      expect(calls, 2);
+    },
+  );
 
   test('unselected Smart saves without activation or servers; stale settings are rejected', () async {
     final original = ConnectionConfiguration(

--- a/test/service/shared/share/configuration_transfer_test.dart
+++ b/test/service/shared/share/configuration_transfer_test.dart
@@ -18,6 +18,11 @@ import 'package:onexray/service/shared/share/configuration_transfer.dart';
 String template(String name, {bool assets = false}) => jsonEncode({
   'name': name,
   'outbounds': [{}, {}],
+  'dns': {
+    'servers': [
+      {'tag': 'app-dns-direct', 'address': '1.1.1.1'},
+    ],
+  },
   'routing': {
     'rules': [
       {
@@ -47,6 +52,11 @@ void main() {
     expect(content.assets.single.fileName, 'rules.dat');
     expect(content.assets.single.type, GeoDataType.domain);
     expect(json['outbounds'], [{}, {}]);
+    expect(json['dns'], {
+      'servers': [
+        {'tag': 'app-dns-direct', 'address': '1.1.1.1'},
+      ],
+    });
     expect(
       (json['routing']['rules'] as List).single['ruleTag'],
       'Local websites',
@@ -125,6 +135,11 @@ void main() {
       expect(link.name, 'Shared');
       expect(jsonDecode(link.xrayJson)['name'], 'Shared');
       expect(jsonDecode(link.xrayJson)['outbounds'], [{}, {}]);
+      expect(jsonDecode(link.xrayJson)['dns'], {
+        'servers': [
+          {'tag': 'app-dns-direct', 'address': '1.1.1.1'},
+        ],
+      });
     },
   );
 


### PR DESCRIPTION
## Summary

- Add a configurable local/direct DNS address to Smart Routing and each Custom Routing profile, while keeping proxy DNS fixed at `8.8.8.8`.
- Make the VPN Tunnel IPv4 DNS, IPv6 DNS, and DNS server name editable and apply them through the existing platform configuration paths.
- Share DNS construction across configuration validation and runtime compilation, with updated documentation and translations in all five supported languages.

## Behavior and persistence

- Custom Routing stores and shares one standard `dns.servers` entry identified by the fixed `app-dns-direct` tag. Runtime-only domain matches, fallback settings, and query strategies are generated by the App.
- Existing profiles without DNS settings retain the previous Google DNS defaults. Settings remain in the existing JSON storage; no database schema upgrade is needed.
- Smart Routing preserves the saved address when its local-DNS switch is disabled. All-via-VPN mode still uses only the proxy DNS server.
- Tunnel DNS remains independent of routing DNS and does not overwrite Raw JSON resolver addresses. The DNS server name is used only for Apple DNS over TLS.
- Validate Xray resolver syntax through libXray and native tunnel addresses as IP literals. Apply effective changes through the existing save/reconnect workflow; inactive settings do not trigger a reconnect.

## Validation

Implementation verification completed before this PR was opened:

- Full Flutter test suite: 916 tests passed.
- `flutter analyze --no-pub`: no issues.
- Layer dependency and native model contract checks passed.
- macOS debug build passed.

PR creation rechecked the remote commit range and `git diff --check`; it did not rerun Flutter commands. Live VPN behavior and Windows/Linux native builds were not verified.

Addresses #181.
